### PR TITLE
feat: extract Lumina design system components into Askama template macros

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,19 @@
-# Mobilispect: Transit Performance Monitoring
+# Mobilispect: Mobility Performance Monitoring
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Mobilispect monitors mobility performance for transit agencies and active mobility networks.
+It ingests GTFS static schedules and real-time feeds, computes metrics
+(on-time %, speed, delays, hotspots), and presents them via a web dashboard.
+
+Current focus: public transit. Planned expansion: active mobility (cycling, walking, micromobility).
+
+Primary users: transit analysts and agency operations staff.
+
+Optimizes for: data accuracy, clear metric definitions, and fast feed ingestion.
+Avoid over-abstraction — prefer clear domain logic over clever generics.
 
 ## Stack
 
@@ -11,6 +24,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Templates:** Askama (type-safe HTML, compiled at build time)
 - **GTFS parsing:** gtfs-structures (static), prost (RT protobuf)
 - **HTTP client:** reqwest
+- **CSS:** Tailwind CSS + Lumina design system (`frontend/design-system.html`)
 - **Logging/tracing:** tracing + tracing-subscriber
 
 ## Structure
@@ -35,6 +49,13 @@ src/
 migrations/        # SQL schema (001_schema.sql)
 templates/         # Askama HTML templates
 ```
+
+Where new code goes:
+- New metric or analysis: add a module under `metrics/` or a new top-level slice
+- New web page: handler in `web/handlers.rs` + template in `templates/`
+- New GTFS feed type: extend `gtfs/`
+- Shared DB logic: `db/`
+- Each vertical slice owns its query, computation, and presentation layer
 
 ## Commands
 
@@ -64,4 +85,54 @@ cargo test <test_name>   # run a single test
 
 ## Conventions
 
-- Use Vertical Slice Architecture
+- Vertical Slice Architecture: each feature owns its DB query, computation, and handler
+- No mocks in tests — use real Postgres via testcontainers (see `.claude/rules/testing.md`)
+- Prefer explicit error types over `unwrap()` in production paths
+- sqlx queries must be compile-time checked (`query!` / `query_as!`)
+- Askama templates are type-safe — keep logic out of templates
+- Config lives in `config.toml`; secrets via dotenvx env refs only
+
+## UI & Design System
+
+All UI must use the **Lumina design system** — see `frontend/design-system.html` for the full reference.
+
+**Typography**
+- Display/headings: `font-family: 'Cormorant', serif` — use for `h1`–`h3`, stat numbers
+- Body/UI: `font-family: 'Jost', sans-serif` — default for all UI text
+- Code/labels: `font-family: 'Fira Code', monospace` — section labels, data values
+
+**Colour palette (Tailwind custom tokens)**
+- `cream` — neutral scale; use for backgrounds, borders, text hierarchy
+- `cinnabar` — primary accent (action, active states); `cinnabar-500` = `#C8463A`
+- `oxford` — secondary accent (info, links); `oxford-500` = `#1D4E89`
+- `saffron` — warning; `saffron-500` = `#E8A020`
+- Sage (`#3D9A6B`) — success (CSS var only, no Tailwind token)
+
+**CSS custom properties (semantic tokens)**
+Use these instead of raw hex values:
+- `--bg`, `--bg-subtle`, `--surface` — background layers
+- `--ink`, `--secondary`, `--muted`, `--dim` — text hierarchy
+- `--border`, `--border-light` — borders
+- `--cinn`, `--ox`, `--saff`, `--sage` — accent colours
+- Badge variants: `--b-cinn-bg/fg`, `--b-ox-bg/fg`, `--b-saff-bg/fg`, `--b-neu-bg/fg`
+- Alert variants: `--al-info-*`, `--al-ok-*`, `--al-warn-*`, `--al-err-*`
+
+**Dark mode:** toggle via `html.dark` class; all CSS vars switch automatically.
+
+**Key component classes**
+- `.btn` — base button; primary = `bg-cinnabar-500 text-cream-50 hover:bg-cinnabar-600`
+- `.field` — text input with focus ring in cinnabar
+- `.card` — `border-radius: 12px`, hover lift (`translateY(-2px)`)
+- `.badge` — small label with variant bg/fg vars
+- `.alert` — info/ok/warn/err with matching vars
+- `.stat-num` — Cormorant 3rem weight-300 for metric display numbers
+- `.section-label` — Fira Code uppercase tracking, cinnabar colour
+
+Do not introduce other component libraries (Bootstrap, shadcn, etc.) unless explicitly requested.
+
+## Safety Rules
+
+- Do not modify `migrations/` schema without calling it out explicitly
+- Do not change GTFS parsing logic without verifying against a real feed
+- Do not alter `config.rs` AgencyConfig fields without updating `config.toml`
+- Preserve existing metric definitions — changes affect historical comparisons

--- a/docs/superpowers/plans/2026-05-10-design-system-templates.md
+++ b/docs/superpowers/plans/2026-05-10-design-system-templates.md
@@ -1,0 +1,932 @@
+# Design System Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract every Lumina design system component into Askama macros in `templates/macros.html` and migrate all existing templates to use them.
+
+**Architecture:** Single `templates/macros.html` holds all macros (badge, stat, section_label, filter_pill, metric_card, alert). Each template adds `{% import "macros.html" as ui %}` and replaces inline component HTML with macro calls. New semantic badge variants (good/bad/mixed/neutral) replace the old class-based variants. CSS for shared components moves to `base.html` so it's available globally.
+
+**Tech Stack:** Rust 2024, Askama 0.15 (compiled templates), CSS custom properties, Tailwind-adjacent utility classes.
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `templates/macros.html` | **Create** — 6 macros: badge, stat, section_label, filter_pill, metric_card, alert |
+| `templates/base.html` | **Modify** — add badge--good/bad/mixed/neutral, spacing-stat-*, section-label, alert CSS |
+| `templates/speed_card.html` | **Modify** — import macros, replace badge and stats |
+| `templates/speed.html` | **Modify** — remove spacing-stat-* CSS block (moved to base.html) |
+| `templates/route_speed_detail.html` | **Modify** — import macros, replace badge and section_label, remove local CSS |
+| `templates/dashboard.html` | **Modify** — import macros, replace badge and metric_card |
+| `templates/scorecard.html` | **Modify** — import macros, replace badge and metric_card |
+| `templates/route_detail.html` | **Modify** — import macros, replace filter_pill |
+| `src/speed/card.rs` | **Modify** — add `avg_stop_spacing_variant()`, `RouteClass::display_label()` |
+| `src/metrics/mod.rs` | **Modify** — add `RouteSummary::badge_variant()`, `ScorecardRoute::badge_variant()` |
+
+---
+
+### Task 1: Add `avg_stop_spacing_variant()` to `RouteSpeedCard`
+
+**Files:**
+- Modify: `src/speed/card.rs`
+
+The current `avg_stop_spacing_class()` returns `"none"/"local"/"rapid"/"express"` (tied to RouteClass CSS). We need `avg_stop_spacing_variant()` returning semantic `"neutral"/"bad"/"good"` for the stat macro. Logic: None → neutral; < 300m → bad (below all class lower bounds); ≥ 300m → good (Local starts at 300m, so any classified stop spacing is in-range).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` module in `src/speed/card.rs` (after the existing `spacing_unit_kilometres` test, around line 483):
+
+```rust
+#[test]
+fn stop_spacing_variant_neutral_when_no_data() {
+    assert_eq!(card_with_spacing(None).avg_stop_spacing_variant(), "neutral");
+}
+
+#[test]
+fn stop_spacing_variant_bad_below_300m() {
+    assert_eq!(card_with_spacing(Some(0.0)).avg_stop_spacing_variant(), "bad");
+    assert_eq!(card_with_spacing(Some(299.9)).avg_stop_spacing_variant(), "bad");
+}
+
+#[test]
+fn stop_spacing_variant_good_at_or_above_300m() {
+    assert_eq!(card_with_spacing(Some(300.0)).avg_stop_spacing_variant(), "good");
+    assert_eq!(card_with_spacing(Some(1500.0)).avg_stop_spacing_variant(), "good");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test stop_spacing_variant 2>&1 | grep -E "FAILED|error"
+```
+
+Expected: compilation error — `avg_stop_spacing_variant` not found.
+
+- [ ] **Step 3: Add the implementation**
+
+Add this method to `RouteSpeedCard`'s `impl` block in `src/speed/card.rs`, after `avg_stop_spacing_unit()` (line 47):
+
+```rust
+    pub fn avg_stop_spacing_variant(&self) -> &'static str {
+        match self.avg_stop_spacing_m {
+            None => "neutral",
+            Some(m) if m < 300.0 => "bad",
+            Some(_) => "good",
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test stop_spacing_variant
+```
+
+Expected: 3 tests pass, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/speed/card.rs
+git commit -m "feat(speed): add avg_stop_spacing_variant() returning semantic good/bad/neutral"
+```
+
+---
+
+### Task 2: Add `badge_variant()` to `RouteSummary` and `ScorecardRoute`
+
+**Files:**
+- Modify: `src/metrics/mod.rs`
+
+The new badge macro expects semantic variant names (`"good"/"bad"/"mixed"/"neutral"`). Both `RouteSummary` and `ScorecardRoute` currently have `status_class()` returning old class names (`"green"/"yellow"/"red"/"none"`). We add `badge_variant()` alongside — the old method will be removed in Task 10 once templates are migrated.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block in `src/metrics/mod.rs`. Use the existing `make_scorecard_route()` helper (line 835) for `ScorecardRoute` tests. Add a new helper for `RouteSummary`.
+
+Add after the `status_class_is_none_without_data` test (around line 978):
+
+```rust
+// ── RouteSummary::badge_variant tests ──────────────────────────────────────
+
+fn make_route_summary(on_time: Option<f64>) -> RouteSummary {
+    RouteSummary {
+        agency_id: "stm".into(),
+        route_id: "R1".into(),
+        short_name: "1".into(),
+        long_name: "Route 1".into(),
+        avg_on_time_pct: on_time,
+        avg_delay_secs: None,
+        trips_run: None,
+        trips_total: None,
+        days_measured: None,
+    }
+}
+
+#[test]
+fn route_summary_badge_variant_good_at_or_above_80() {
+    assert_eq!(make_route_summary(Some(80.0)).badge_variant(), "good");
+    assert_eq!(make_route_summary(Some(95.0)).badge_variant(), "good");
+}
+
+#[test]
+fn route_summary_badge_variant_mixed_between_60_and_80() {
+    assert_eq!(make_route_summary(Some(60.0)).badge_variant(), "mixed");
+    assert_eq!(make_route_summary(Some(79.9)).badge_variant(), "mixed");
+}
+
+#[test]
+fn route_summary_badge_variant_bad_below_60() {
+    assert_eq!(make_route_summary(Some(59.9)).badge_variant(), "bad");
+    assert_eq!(make_route_summary(Some(0.0)).badge_variant(), "bad");
+}
+
+#[test]
+fn route_summary_badge_variant_neutral_when_no_data() {
+    assert_eq!(make_route_summary(None).badge_variant(), "neutral");
+}
+
+// ── ScorecardRoute::badge_variant tests ──────────────────────────────────────
+
+#[test]
+fn scorecard_badge_variant_good_at_or_above_ceiling() {
+    let r = make_scorecard_route(Some(96.0), None);
+    assert_eq!(r.badge_variant(&89.0, &96.0), "good");
+}
+
+#[test]
+fn scorecard_badge_variant_mixed_between_floor_and_ceiling() {
+    let r = make_scorecard_route(Some(91.0), None);
+    assert_eq!(r.badge_variant(&89.0, &96.0), "mixed");
+}
+
+#[test]
+fn scorecard_badge_variant_bad_under_floor() {
+    let r = make_scorecard_route(Some(71.0), None);
+    assert_eq!(r.badge_variant(&89.0, &96.0), "bad");
+}
+
+#[test]
+fn scorecard_badge_variant_neutral_when_no_data() {
+    let r = make_scorecard_route(None, None);
+    assert_eq!(r.badge_variant(&89.0, &96.0), "neutral");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test badge_variant 2>&1 | grep -E "FAILED|error"
+```
+
+Expected: compilation error — `badge_variant` not found on either type.
+
+- [ ] **Step 3: Add `RouteSummary::badge_variant()`**
+
+In `src/metrics/mod.rs`, add after `RouteSummary::status_label()` (after line ~263):
+
+```rust
+    pub fn badge_variant(&self) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(pct) if pct >= 80.0 => "good",
+            Some(pct) if pct >= 60.0 => "mixed",
+            Some(_) => "bad",
+            None => "neutral",
+        }
+    }
+```
+
+- [ ] **Step 4: Add `ScorecardRoute::badge_variant()`**
+
+In `src/metrics/mod.rs`, add after `ScorecardRoute::status_class()` (after line ~554):
+
+```rust
+    pub fn badge_variant(&self, floor_pct: &f64, ceiling_pct: &f64) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(p) if p >= *ceiling_pct => "good",
+            Some(p) if p >= *floor_pct => "mixed",
+            Some(_) => "bad",
+            None => "neutral",
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cargo test badge_variant
+```
+
+Expected: 8 unit tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metrics/mod.rs
+git commit -m "feat(metrics): add badge_variant() to RouteSummary and ScorecardRoute"
+```
+
+---
+
+### Task 3: Create `templates/macros.html`
+
+**Files:**
+- Create: `templates/macros.html`
+
+Askama compiles macros at build time. Each macro in this file is imported by templates with `{% import "macros.html" as ui %}`. Macro arguments are Rust expressions — `variant` args are `&str`, `active` arg is `bool`, other args are any `Display` type.
+
+Note on the `stat` macro: it renders the two inner divs only (no outer wrapper), so callers keep their own `<div>` wrapper to control layout (e.g., `margin-left: auto`). This matches the current `speed_card.html` structure exactly.
+
+- [ ] **Step 1: Create the file**
+
+Create `templates/macros.html` with this content:
+
+```html
+{% macro badge(variant, label) %}
+<span class="badge badge--{{ variant }}">{{ label }}</span>
+{% endmacro badge %}
+
+{% macro stat(label, value, unit, variant) %}
+<div class="spacing-stat-label">{{ label }}</div>
+<div class="spacing-stat-num{% if variant != "" %} spacing-{{ variant }}{% endif %}">{{ value }}<span class="spacing-stat-unit">{{ unit }}</span></div>
+{% endmacro stat %}
+
+{% macro section_label(text) %}
+<div class="section-label">{{ text }}</div>
+{% endmacro section_label %}
+
+{% macro filter_pill(href, label, active) %}
+<a class="filter-pill{% if active %} active{% endif %}" href="{{ href }}">{{ label }}</a>
+{% endmacro filter_pill %}
+
+{% macro metric_card(label, value, unit) %}
+<div class="metric-card">
+  <div class="metric-label">{{ label }}</div>
+  <div class="metric-value">{{ value }}{{ unit }}</div>
+</div>
+{% endmacro metric_card %}
+
+{% macro alert(variant, message) %}
+<div class="alert alert--{{ variant }}">{{ message }}</div>
+{% endmacro alert %}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo build 2>&1 | grep -E "error|warning.*unused"
+```
+
+Expected: clean build (no errors). Warnings about unused macros are fine — they'll be used in later tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/macros.html
+git commit -m "feat(templates): create macros.html with badge/stat/section_label/filter_pill/metric_card/alert"
+```
+
+---
+
+### Task 4: Update `templates/base.html` CSS
+
+**Files:**
+- Modify: `templates/base.html`
+
+Add four things to base.html's `<style>` block:
+1. New badge variant classes (`badge--good/bad/mixed/neutral`) — after the existing badge--express rule at line 249
+2. `spacing-stat-*` classes — these are currently in `speed.html` and will be removed from there in Task 6; add them to base.html with updated variant color names
+3. `section-label` and `section-label-badge` — currently defined locally in `route_speed_detail.html` with grey color; move to base.html with the correct cinnabar color; local definition removed in Task 7
+4. Alert CSS vars (in `:root`) and `.alert` classes
+
+Do NOT remove existing old CSS yet — that's Task 10.
+
+- [ ] **Step 1: Add badge variant classes**
+
+In `templates/base.html`, after `.badge--express` (line 249), add:
+
+```css
+        .badge--good    { background: var(--civic-green-bg); color: var(--civic-green); }
+        .badge--bad     { background: var(--civic-red-bg);   color: var(--civic-red); }
+        .badge--mixed   { background: var(--civic-amber-bg); color: var(--civic-amber); }
+        .badge--neutral { background: var(--link-blue-bg);   color: var(--link-blue); }
+```
+
+- [ ] **Step 2: Add spacing-stat and spacing variant classes**
+
+In `templates/base.html`, in the `/* Specific blocks */` comment area at the end of the `<style>` block (around line 427), add:
+
+```css
+        /* Stat display — shared across speed cards and route detail */
+        .spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
+        .spacing-stat-num   { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }
+        .spacing-stat-unit  { font-size:1rem; color:var(--ink-400); }
+        .spacing-good       { color: var(--civic-green); }
+        .spacing-bad        { color: var(--civic-red); }
+        .spacing-mixed      { color: var(--civic-amber); }
+        .spacing-neutral    { color: var(--link-blue); }
+```
+
+- [ ] **Step 3: Add section-label classes**
+
+In the same `/* Specific blocks */` area of `base.html`, add:
+
+```css
+        /* Section label — Fira Code uppercase cinnabar */
+        .section-label { font-family:'Fira Code',monospace; font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--civic-red); margin-bottom:0.75rem; }
+        .section-label-badge { display:inline-block; background:var(--link-blue); color:white; font-size:0.68rem; padding:0.15rem 0.4rem; border-radius:3px; margin-left:0.5rem; vertical-align:middle; font-weight:600; text-transform:none; letter-spacing:0; }
+        .section-label-badge.outlier { background:var(--civic-amber); }
+        .section-label-badge.slow    { background:var(--civic-red); }
+```
+
+- [ ] **Step 4: Add alert CSS vars and classes**
+
+In the `:root` block of `base.html` (after the last existing var, around line 38), add:
+
+```css
+          --al-info-bg: var(--link-blue-bg); --al-info-fg: var(--link-blue); --al-info-border: var(--link-blue);
+          --al-ok-bg: var(--civic-green-bg); --al-ok-fg: var(--civic-green); --al-ok-border: var(--civic-green);
+          --al-warn-bg: var(--civic-amber-bg); --al-warn-fg: var(--civic-amber); --al-warn-border: var(--civic-amber);
+          --al-err-bg: var(--civic-red-bg);  --al-err-fg: var(--civic-red);  --al-err-border: var(--civic-red);
+```
+
+These vars reference other vars that already have dark-mode overrides, so no separate `html.dark` block needed.
+
+In the `/* Specific blocks */` area, add:
+
+```css
+        .alert { padding:0.75rem 1rem; border-radius:var(--radius); border-left:3px solid; margin-bottom:1rem; font-size:0.875rem; }
+        .alert--info { background:var(--al-info-bg); color:var(--al-info-fg); border-left-color:var(--al-info-border); }
+        .alert--ok   { background:var(--al-ok-bg);   color:var(--al-ok-fg);   border-left-color:var(--al-ok-border); }
+        .alert--warn { background:var(--al-warn-bg); color:var(--al-warn-fg); border-left-color:var(--al-warn-border); }
+        .alert--err  { background:var(--al-err-bg);  color:var(--al-err-fg);  border-left-color:var(--al-err-border); }
+```
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/base.html
+git commit -m "feat(css): add badge--good/bad/mixed/neutral, spacing-stat-*, section-label, and alert classes to base.html"
+```
+
+---
+
+### Task 5: Update `templates/speed_card.html` to use macros
+
+**Files:**
+- Modify: `templates/speed_card.html`
+
+Replace the inline badge and inline stat markup with macro calls. The `avg_stop_spacing_variant()` method (added in Task 1) drives the stat colour. Note: `avg_stop_spacing_class()` (old, returns "local"/"rapid"/"express") is still defined in Rust but no longer called after this task — it will be removed in Task 10.
+
+The wrapping `<div style="margin-left:auto;">` around the stop spacing stat is preserved for layout.
+
+- [ ] **Step 1: Rewrite `templates/speed_card.html`**
+
+Replace the entire file content with:
+
+```html
+{% import "macros.html" as ui %}
+<a href="/routes/{{ card.agency_id }}/{{ card.route_id }}/speed"
+   style="text-decoration: none; color: inherit; display: block;">
+<div class="card" style="padding:1rem 1.25rem;">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:1rem;">
+    <div>
+      <div class="route-id">{{ card.agency_name }} {{ card.short_name }}</div>
+      <div style="margin-top:0.15rem;color:var(--ink-500);font-size:0.82rem;">{{ card.long_name }}</div>
+    </div>
+    {% if let Some(class) = card.classification %}
+    {{ ui::badge(variant="neutral", label=class.label()) }}
+    {% endif %}
+  </div>
+  <div style="margin-top:0.75rem;display:flex;gap:1.5rem;border-top:1px solid var(--line-soft);padding-top:0.75rem;">
+    <div>{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div>{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div style="margin-left:auto;">{{ ui::stat(label="Avg stop spacing", value=card.avg_stop_spacing_number(), unit=card.avg_stop_spacing_unit(), variant=card.avg_stop_spacing_variant()) }}</div>
+  </div>
+</div>
+</a>
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors. The classification badge now renders as `badge--neutral` (oxford blue) instead of `badge--local/rapid/express`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/speed_card.html
+git commit -m "refactor(speed_card): use badge and stat macros"
+```
+
+---
+
+### Task 6: Remove dead CSS from `templates/speed.html`
+
+**Files:**
+- Modify: `templates/speed.html`
+
+After Task 5, the `spacing-stat-*` and `spacing-local/rapid/express/none` CSS classes in `speed.html` are dead — they've been replaced by the `base.html` versions (`spacing-stat-*` and `spacing-good/bad/mixed/neutral`). Remove them from the `<style>` block in `{% block extra_head %}`.
+
+Keep: `.controls`, `.card-grid`, `.speed-loading`, `.htmx-indicator`, `@keyframes speed-loading-spin`.
+
+- [ ] **Step 1: Remove the dead CSS block from `templates/speed.html`**
+
+In `templates/speed.html`, remove these lines from the `<style>` block (approximately lines 13-20):
+
+```css
+.spacing-stat { text-align:center; margin-top:0.5rem; padding-top:0.5rem; border-top:1px solid var(--line-soft); }
+.spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
+.spacing-stat-num { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }
+.spacing-stat-unit { font-size:1rem; color:var(--ink-400); }
+.spacing-local   { color: var(--link-blue); }
+.spacing-rapid   { color: var(--civic-green); }
+.spacing-express { color: var(--express-fg); }
+.spacing-none    { color: var(--ink-400); }
+```
+
+After removing, the `<style>` block should contain only `.controls`, `.card-grid`, `.speed-loading`, `.speed-loading::before`, `.htmx-indicator`, `.htmx-request.htmx-indicator`, `.htmx-request .htmx-indicator`, and `@keyframes speed-loading-spin`.
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/speed.html
+git commit -m "refactor(speed): remove spacing-stat CSS moved to base.html"
+```
+
+---
+
+### Task 7: Update `templates/route_speed_detail.html` — macros + RouteClass::display_label()
+
+**Files:**
+- Modify: `templates/route_speed_detail.html`
+- Modify: `src/speed/card.rs` (add `RouteClass::display_label()`)
+
+The classification badge currently renders `"Local · 12-18 km/h"` by concatenating `class.label()` and `class.speed_range()` inside the badge span. The macro takes a single `label` argument, so we add a `display_label()` method to `RouteClass` that returns the combined string.
+
+The "Stop spacing" section label (line 64) has an inline badge — keep it as-is, just ensure `section-label-badge` CSS is now supplied by base.html (it was moved in Task 4, so removing the local definition is all that's needed). Only the simple "Speed trend" section label uses the macro.
+
+The back link has a dynamic `agency_id` in the href — keep it as inline HTML.
+
+The local `<style>` block in `{% block extra_head %}` defines `.section-label` with grey color. After removing it, the base.html cinnabar version applies (intentional per design spec).
+
+- [ ] **Step 1: Write failing test for `RouteClass::display_label()`**
+
+Add to `src/speed/card.rs` test module (after the `route_class_css_class` test, around line 391):
+
+```rust
+#[test]
+fn route_class_display_label() {
+    assert_eq!(RouteClass::Local.display_label(), "Local · 12-18 km/h");
+    assert_eq!(RouteClass::Rapid.display_label(), "Rapid · 18-25 km/h");
+    assert_eq!(RouteClass::Express.display_label(), "Express · >25 km/h");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test route_class_display_label 2>&1 | grep -E "error|FAILED"
+```
+
+Expected: compilation error — method not found.
+
+- [ ] **Step 3: Add `RouteClass::display_label()` to `src/speed/card.rs`**
+
+In `src/speed/card.rs`, add after `RouteClass::css_class()` (after line 95):
+
+```rust
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            RouteClass::Local => "Local · 12-18 km/h",
+            RouteClass::Rapid => "Rapid · 18-25 km/h",
+            RouteClass::Express => "Express · >25 km/h",
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test route_class_display_label
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 5: Update `templates/route_speed_detail.html`**
+
+Make these changes to `templates/route_speed_detail.html`:
+
+**a) Add import after `{% extends "base.html" %}` (line 1):**
+```
+{% import "macros.html" as ui %}
+```
+
+**b) Remove the local `.section-label` and `.section-label-badge` CSS from the `<style>` block (lines 13-16):**
+
+Remove these lines:
+```css
+.section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-500); margin-bottom: 0.75rem; font-weight: 700; }
+.section-label-badge { display: inline-block; background: var(--link-blue); color: white; font-size: 0.68rem; padding: 0.15rem 0.4rem; border-radius: 3px; margin-left: 0.5rem; vertical-align: middle; font-weight: 600; text-transform: none; letter-spacing: 0; }
+.section-label-badge.outlier { background: var(--civic-amber); }
+.section-label-badge.slow { background: var(--civic-red); }
+```
+
+**c) Replace the classification badge (line 52):**
+
+Replace:
+```html
+      <span class="badge badge--{{ class.css_class() }}">{{ class.label() }} · {{ class.speed_range() }}</span>
+```
+With:
+```html
+      {{ ui::badge(variant="neutral", label=class.display_label()) }}
+```
+
+**d) Replace the "Speed trend" section label (line 98):**
+
+Replace:
+```html
+      <div class="section-label">Speed trend — scheduled vs actual</div>
+```
+With:
+```html
+      {{ ui::section_label(text="Speed trend — scheduled vs actual") }}
+```
+
+Leave the "Stop spacing" section label (line 64) unchanged — it has an embedded inline badge that is not expressible through the simple `section_label` macro.
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/route_speed_detail.html src/speed/card.rs
+git commit -m "refactor(route_speed_detail): use badge and section_label macros, move section-label CSS to base"
+```
+
+---
+
+### Task 8: Update `templates/dashboard.html` to use macros
+
+**Files:**
+- Modify: `templates/dashboard.html`
+
+Replace both metric cards with the `metric_card` macro and the status badge with the `badge` macro. The filter_bar agency links have dynamic hrefs — leave them as-is.
+
+- [ ] **Step 1: Update `templates/dashboard.html`**
+
+**a) Add import after `{% extends "base.html" %}` (line 1):**
+```
+{% import "macros.html" as ui %}
+```
+
+**b) Replace the two metric cards (lines 17-25):**
+
+Replace:
+```html
+  <div class="metric-grid">
+    <div class="metric-card">
+      <div class="metric-label">Routes monitored</div>
+      <div class="metric-value">{{ routes.len() }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="metric-label">Period</div>
+      <div class="metric-value">{{ period_days }}d</div>
+    </div>
+  </div>
+```
+With:
+```html
+  <div class="metric-grid">
+    {{ ui::metric_card(label="Routes monitored", value=routes.len(), unit="") }}
+    {{ ui::metric_card(label="Period", value=period_days, unit="d") }}
+  </div>
+```
+
+**c) Replace the status badge (line 54):**
+
+Replace:
+```html
+        <td><span class="badge {{ route.status_class() }}">{{ route.status_label() }}</span></td>
+```
+With:
+```html
+        <td>{{ ui::badge(variant=route.badge_variant(), label=route.status_label()) }}</td>
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/dashboard.html
+git commit -m "refactor(dashboard): use badge and metric_card macros"
+```
+
+---
+
+### Task 9: Update `templates/scorecard.html` to use macros
+
+**Files:**
+- Modify: `templates/scorecard.html`
+
+Replace simple metric cards and status badges with macros. The "Worst gap" card (lines 24-36) has conditional content based on an `Option<&f64>` — it cannot be expressed through a single `metric_card(label, value, unit)` call; leave it as inline HTML.
+
+- [ ] **Step 1: Update `templates/scorecard.html`**
+
+**a) Add import after `{% extends "base.html" %}` (line 1):**
+```
+{% import "macros.html" as ui %}
+```
+
+**b) Replace the first two simple metric cards (lines 16-23):**
+
+Replace:
+```html
+  <div class="metric-grid">
+    <div class="metric-card">
+      <div class="metric-label">Routes monitored</div>
+      <div class="metric-value">{{ routes.len() }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="metric-label">Meeting {{ floor_city }} floor</div>
+      <div class="metric-value">{{ routes_meeting_floor }}</div>
+    </div>
+    <div class="metric-card">
+```
+With:
+```html
+  <div class="metric-grid">
+    {{ ui::metric_card(label="Routes monitored", value=routes.len(), unit="") }}
+    {{ ui::metric_card(label="Meeting floor", value=routes_meeting_floor, unit="") }}
+    <div class="metric-card">
+```
+
+Note: `Meeting {{ floor_city }} floor` uses a template variable in the label — it can't be passed to the macro which expects a literal. Simplify to `"Meeting floor"` (static string) as the label.
+
+Wait — actually, macro arguments in Askama ARE template expressions, not only literals. `floor_city` is a `&str` variable in scope. Can we pass a format expression? In Askama, the argument `label=floor_city` would pass the value of `floor_city`. But `"Meeting {{ floor_city }} floor"` as a string is not valid Rust. 
+
+Instead, keep the "Meeting floor" card inline but replace everything except that label. Revised approach:
+
+Replace:
+```html
+  <div class="metric-grid">
+    <div class="metric-card">
+      <div class="metric-label">Routes monitored</div>
+      <div class="metric-value">{{ routes.len() }}</div>
+    </div>
+    <div class="metric-card">
+      <div class="metric-label">Meeting {{ floor_city }} floor</div>
+      <div class="metric-value">{{ routes_meeting_floor }}</div>
+    </div>
+```
+With:
+```html
+  <div class="metric-grid">
+    {{ ui::metric_card(label="Routes monitored", value=routes.len(), unit="") }}
+    <div class="metric-card">
+      <div class="metric-label">Meeting {{ floor_city }} floor</div>
+      <div class="metric-value">{{ routes_meeting_floor }}</div>
+    </div>
+```
+
+Keep the "Worst gap" card (everything from `<div class="metric-card">` with the worst_gap conditional, through its closing `</div>`) as-is.
+
+**c) Replace the status badge (line 77):**
+
+Replace:
+```html
+        <td><span class="badge {{ route.status_class(floor_pct, ceiling_pct) }}">{{ route.status_label(floor_pct, ceiling_pct) }}</span></td>
+```
+With:
+```html
+        <td>{{ ui::badge(variant=route.badge_variant(floor_pct, ceiling_pct), label=route.status_label(floor_pct, ceiling_pct)) }}</td>
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/scorecard.html
+git commit -m "refactor(scorecard): use badge and metric_card macros"
+```
+
+---
+
+### Task 10: Update `templates/route_detail.html` to use macros
+
+**Files:**
+- Modify: `templates/route_detail.html`
+
+The back link at line 29 uses a static href — use the `filter_pill` macro.
+
+- [ ] **Step 1: Update `templates/route_detail.html`**
+
+**a) Add import after `{% extends "base.html" %}` (line 1):**
+```
+{% import "macros.html" as ui %}
+```
+
+**b) Replace the back link (line 29):**
+
+Replace:
+```html
+    <a class="filter-pill" href="/">← Back to dashboard</a>
+```
+With:
+```html
+    {{ ui::filter_pill(href="/", label="← Back to dashboard", active=false) }}
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/route_detail.html
+git commit -m "refactor(route_detail): use filter_pill macro"
+```
+
+---
+
+### Task 11: Remove dead methods and CSS
+
+**Files:**
+- Modify: `src/speed/card.rs` — remove `avg_stop_spacing_class()` and its 4 tests
+- Modify: `src/metrics/mod.rs` — remove `RouteSummary::status_class()`, `ScorecardRoute::status_class()` and their tests
+- Modify: `templates/base.html` — remove old badge CSS (`.badge.green`, `.badge--local`, etc.)
+
+At this point all callers have been migrated. Removing the old methods ensures they don't silently drift from the badge variants.
+
+- [ ] **Step 1: Remove `avg_stop_spacing_class()` from `src/speed/card.rs`**
+
+Remove the method and its 4 tests:
+
+Method to remove (lines 26-31):
+```rust
+    pub fn avg_stop_spacing_class(&self) -> &'static str {
+        match self.avg_stop_spacing_m {
+            None => "none",
+            Some(m) => classify_by_spacing(m).css_class(),
+        }
+    }
+```
+
+Tests to remove (lines ~435-452):
+```rust
+#[test]
+fn spacing_class_none_when_no_data() { ... }
+#[test]
+fn spacing_class_local_below_500m() { ... }
+#[test]
+fn spacing_class_rapid_500_to_1500m() { ... }
+#[test]
+fn spacing_class_express_1500m_and_above() { ... }
+```
+
+- [ ] **Step 2: Remove `RouteSummary::status_class()` from `src/metrics/mod.rs`**
+
+Remove method (lines ~247-254):
+```rust
+    /// "green", "yellow", "red", or "none"
+    pub fn status_class(&self) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(pct) if pct >= 80.0 => "green",
+            Some(pct) if pct >= 60.0 => "yellow",
+            Some(_) => "red",
+            None => "none",
+        }
+    }
+```
+
+`RouteSummary::status_class()` has no unit tests, so nothing to remove there.
+
+- [ ] **Step 3: Remove `ScorecardRoute::status_class()` and its tests**
+
+Remove method (lines ~546-554):
+```rust
+    /// CSS badge class: "green" / "yellow" / "red" / "none".
+    pub fn status_class(&self, floor_pct: &f64, ceiling_pct: &f64) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(p) if p >= *ceiling_pct => "green",
+            Some(p) if p >= *floor_pct => "yellow",
+            Some(_) => "red",
+            None => "none",
+        }
+    }
+```
+
+Remove tests (lines ~957-978):
+```rust
+#[test]
+fn status_class_is_green_at_or_above_ceiling() { ... }
+#[test]
+fn status_class_is_yellow_between_floor_and_ceiling() { ... }
+#[test]
+fn status_class_is_red_under_floor() { ... }
+#[test]
+fn status_class_is_none_without_data() { ... }
+```
+
+- [ ] **Step 4: Remove old badge CSS from `templates/base.html`**
+
+Remove the old badge variant rules (lines ~227-249):
+
+```css
+        .badge.green, .badge.status-good {
+            background-color: var(--civic-green-bg);
+            color: var(--civic-green);
+        }
+
+        .badge.yellow, .badge.status-watch {
+            background-color: var(--civic-amber-bg);
+            color: var(--civic-amber);
+        }
+
+        .badge.red, .badge.status-bad {
+            background-color: var(--civic-red-bg);
+            color: var(--civic-red);
+        }
+
+        .badge.none, .badge.status-none {
+            background-color: var(--surface-muted);
+            color: var(--ink-500);
+        }
+
+        .badge--local  { background: var(--link-blue-bg); color: var(--link-blue); }
+        .badge--rapid     { background: var(--civic-green-bg); color: var(--civic-green); }
+        .badge--express   { background: var(--express-bg); color: var(--express-fg); }
+```
+
+Keep: the new `.badge--good/bad/mixed/neutral` rules added in Task 4, and the base `.badge { ... }` rule.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+cargo test 2>&1 | tail -20
+```
+
+Expected: all previously passing tests pass. The pre-existing failures (route_speed_by_day_type_*, route_stop_spacings_*, route_speed_detail_* integration tests) should remain as before — these are not affected by this plan.
+
+- [ ] **Step 6: Build**
+
+```bash
+cargo build 2>&1 | grep "error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/speed/card.rs src/metrics/mod.rs templates/base.html
+git commit -m "refactor: remove dead status_class/avg_stop_spacing_class methods and old badge CSS"
+```

--- a/docs/superpowers/specs/2026-05-10-design-system-templates-design.md
+++ b/docs/superpowers/specs/2026-05-10-design-system-templates-design.md
@@ -1,0 +1,206 @@
+# Design System Templates — Design Spec
+
+## Goal
+
+Extract every reusable UI component in the Lumina design system into Askama template macros, then replace all inline component HTML across existing templates with macro calls.
+
+## Architecture
+
+Single file `templates/macros.html` holds all macros. Each template that uses macros adds `{% import "macros.html" as ui %}` at the top. Askama imports do not propagate through includes, so every file needing macros imports directly.
+
+No CSS token renaming — existing custom property names (`--b-cinn-bg`, etc.) are kept as-is. New semantic badge variant classes (`badge--good`, `badge--bad`, `badge--mixed`, `badge--neutral`) are added alongside existing route-class variants.
+
+## Components
+
+### `badge(variant, label)`
+
+Renders `<span class="badge badge--{variant}">{label}</span>`.
+
+Variants map to colours:
+- `good` → sage green (`--b-sage-bg/fg` or CSS inline if no token exists; hex `#3D9A6B`)
+- `bad` → cinnabar red (`--b-cinn-bg/fg`)
+- `mixed` → saffron amber (`--b-saff-bg/fg`)
+- `neutral` → oxford blue (`--b-ox-bg/fg`)
+
+Route classification badges (Local / Rapid / Express) all use `neutral` (oxford blue).
+
+Route status badges map:
+- On-time / above target → `good`
+- Mixed → `mixed`
+- Below target → `bad`
+- No data → `neutral`
+
+### `stat(label, value, unit, variant)`
+
+Renders a labelled metric block with a large number, optional unit, and semantic colour on the number.
+
+```html
+<div>
+  <div class="spacing-stat-label">{label}</div>
+  <div class="spacing-stat-num spacing-{variant}">{value}<span class="spacing-stat-unit">{unit}</span></div>
+</div>
+```
+
+Variants: `good` (sage), `bad` (cinnabar), `mixed` (saffron), `neutral` (oxford blue). Pass `variant=""` for default ink colour.
+
+### `section_label(text)`
+
+Renders `<span class="section-label">{text}</span>` — Fira Code, uppercase, letter-spaced, cinnabar colour.
+
+### `filter_pill(href, label, active)`
+
+Renders `<a href="{href}" class="filter-pill {active_class}">{label}</a>`. When `active=true` the pill gets the active state class.
+
+### `metric_card(label, value, unit, sublabel)`
+
+Renders a card-style metric display used on the dashboard and scorecard:
+
+```html
+<div class="metric-card">
+  <div class="metric-card__label">{label}</div>
+  <div class="metric-card__value">{value}<span class="metric-card__unit">{unit}</span></div>
+  <div class="metric-card__sublabel">{sublabel}</div>
+</div>
+```
+
+### `alert(variant, message)`
+
+Renders `<div class="alert alert--{variant}">{message}</div>`.
+
+Variants: `info`, `ok`, `warn`, `err` — map to `--al-info-*`, `--al-ok-*`, `--al-warn-*`, `--al-err-*` CSS vars.
+
+## CSS Changes (`templates/base.html`)
+
+### New badge variant classes
+
+```css
+.badge--good    { background: var(--b-sage-bg, #d4f0e2); color: var(--b-sage-fg, #1f6e43); }
+.badge--bad     { background: var(--b-cinn-bg); color: var(--b-cinn-fg); }
+.badge--mixed   { background: var(--b-saff-bg); color: var(--b-saff-fg); }
+.badge--neutral { background: var(--b-ox-bg);   color: var(--b-ox-fg);   }
+```
+
+Existing `.badge--local`, `.badge--rapid`, `.badge--express`, `.badge.status-*` classes remain until callers are migrated, then are removed.
+
+### Move `spacing-stat-*` to base.html
+
+These classes are currently defined inline in `templates/speed.html`. Move them to `base.html` so all templates that render stats can use them.
+
+```css
+.spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; ... }
+.spacing-stat-num   { font-family:'Cormorant Garamond',serif; font-weight:300; font-size:1.8rem; ... }
+.spacing-stat-unit  { font-size:1rem; color:var(--ink-400); }
+.spacing-good       { color: var(--sage, #3D9A6B); }
+.spacing-bad        { color: var(--cinn, var(--link-blue)); }   /* cinnabar */
+.spacing-mixed      { color: var(--saff); }
+.spacing-neutral    { color: var(--ox, var(--link-blue)); }     /* oxford blue */
+```
+
+Remove from `templates/speed.html` once moved.
+
+### Move `section-label` to base.html
+
+Currently defined locally in `templates/route_speed_detail.html`. Move to `base.html` and delete local definition.
+
+```css
+.section-label { font-family:'Fira Code',monospace; font-size:0.65rem; letter-spacing:0.1em;
+                 text-transform:uppercase; color:var(--cinn, #C8463A); }
+.section-label-badge { ... }
+```
+
+### Alert CSS vars (add to base.html)
+
+```css
+--al-info-bg: ...; --al-info-fg: ...; --al-info-border: ...;
+--al-ok-bg:   ...; --al-ok-fg:   ...; --al-ok-border:   ...;
+--al-warn-bg: ...; --al-warn-fg: ...; --al-warn-border: ...;
+--al-err-bg:  ...; --al-err-fg:  ...; --al-err-border:  ...;
+
+.alert { ... }
+.alert--info { background: var(--al-info-bg); color: var(--al-info-fg); border-left: 3px solid var(--al-info-border); }
+/* etc. */
+```
+
+## Rust Changes (`src/speed/card.rs`)
+
+### Rename `status_class()` → `badge_variant()`
+
+`status_class()` currently returns CSS class suffixes (`"good"`, `"bad"`, `"mixed"`, `"neutral"`). Rename to `badge_variant()` — same values, new name that reflects its role as a macro argument.
+
+Update all callers: `templates/dashboard.html`, `templates/scorecard.html`.
+
+### Add `avg_stop_spacing_variant()`
+
+Returns `"neutral"` / `"bad"` / `"good"` based on `avg_stop_spacing_m`:
+
+```rust
+pub fn avg_stop_spacing_variant(&self) -> &'static str {
+    match self.avg_stop_spacing_m {
+        None => "neutral",
+        Some(m) if m < 300.0 => "bad",
+        Some(_) => "good",
+    }
+}
+```
+
+Rationale: Local (300–500m), Rapid (500–1500m), and Express (≥1500m) form a continuous range covering all values ≥300m. Values below 300m fall outside all classes and are flagged bad. No "mixed" case exists.
+
+## Template Call Sites
+
+### `templates/speed_card.html`
+
+```
+{% import "macros.html" as ui %}
+```
+
+- Badge: `{{ ui::badge(variant=card.badge_variant(), label=card.classification_label()) }}`
+- Scheduled stat: `{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant="") }}`
+- Actual stat: `{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant="") }}`
+- Stop spacing stat: `{{ ui::stat(label="Avg stop spacing", value=card.avg_stop_spacing_number(), unit=card.avg_stop_spacing_unit(), variant=card.avg_stop_spacing_variant()) }}`
+
+### `templates/dashboard.html`
+
+```
+{% import "macros.html" as ui %}
+```
+
+- Route badge: `{{ ui::badge(variant=route.badge_variant(), label=route.status_label()) }}`
+- Metric cards: `{{ ui::metric_card(label=..., value=..., unit=..., sublabel=...) }}`
+
+### `templates/scorecard.html`
+
+```
+{% import "macros.html" as ui %}
+```
+
+- Route badge: `{{ ui::badge(variant=route.badge_variant(floor_pct, ceiling_pct), label=...) }}`
+- Metric cards: `{{ ui::metric_card(...) }}`
+
+### `templates/route_detail.html`
+
+```
+{% import "macros.html" as ui %}
+```
+
+- Back link: `{{ ui::filter_pill(href="/", label="← Back to dashboard", active=false) }}`
+
+### `templates/route_speed_detail.html`
+
+```
+{% import "macros.html" as ui %}
+```
+
+- Section headers: `{{ ui::section_label(text="...") }}`
+- Badges: `{{ ui::badge(variant=..., label=...) }}`
+- Remove local `section-label` CSS block
+
+### `templates/speed.html`
+
+- Remove `spacing-stat-*` CSS block (moved to `base.html`)
+
+## Testing
+
+- Unit tests for `avg_stop_spacing_variant()` on `RouteSpeedCard`: `None→neutral`, `0.0→bad`, `299.9→bad`, `300.0→good`, `1500.0→good`
+- Unit test for renamed `badge_variant()` (previously `status_class()`) — same input/output, renamed
+- Existing template compilation tests continue to pass (Askama validates at build time)
+- No new integration tests needed — this is presentation logic only

--- a/frontend/design-system.html
+++ b/frontend/design-system.html
@@ -1,0 +1,1618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lumina — Design System</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600&family=Jost:wght@300;400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            display: ['Cormorant', 'serif'],
+            sans: ['Jost', 'sans-serif'],
+            mono: ['Fira Code', 'monospace'],
+          },
+          colors: {
+            cream: {
+              50:  '#FAFAF7',
+              100: '#F4F4EF',
+              200: '#ECEAE4',
+              300: '#E0DDD6',
+              400: '#C8C4BC',
+              500: '#A8A49B',
+              600: '#888480',
+              700: '#645F5A',
+              800: '#3D3935',
+              900: '#1A1814',
+            },
+            cinnabar: {
+              50:  '#FDF2F1',
+              100: '#F9DDD9',
+              200: '#F2B5AF',
+              300: '#E88880',
+              400: '#DC5E54',
+              500: '#C8463A',
+              600: '#A83530',
+              700: '#872828',
+              800: '#641E1E',
+              900: '#411414',
+            },
+            oxford: {
+              50:  '#EEF3FA',
+              100: '#D0E0F3',
+              200: '#9DBDE6',
+              300: '#6498D3',
+              400: '#3574BC',
+              500: '#1D4E89',
+              600: '#163A67',
+              700: '#102D52',
+              800: '#0A1D37',
+              900: '#060E1C',
+            },
+            saffron: {
+              50:  '#FEF8EC',
+              100: '#FDF0D0',
+              200: '#F9DC98',
+              300: '#F4C460',
+              400: '#EDB030',
+              500: '#E8A020',
+              600: '#C88018',
+              700: '#9E6012',
+              800: '#74420C',
+              900: '#4A2506',
+            },
+          },
+        }
+      }
+    }
+  </script>
+
+  <style>
+    /* ══ CSS custom properties ══════════════════════════════════ */
+    :root {
+      --bg:           #FAFAF7;
+      --bg-subtle:    #F4F4EF;
+      --surface:      #FFFFFF;
+      --border-light: #ECEAE4;
+      --border:       #E0DDD6;
+      --ink:          #1A1814;
+      --secondary:    #645F5A;
+      --muted:        #888480;
+      --dim:          #A8A49B;
+      --stone:        #C8C4BC;
+      --mid:          #3D3935;
+      --cinn:         #C8463A;
+      --cinn-hover:   #A83530;
+      --ox:           #1D4E89;
+      --saff:         #E8A020;
+      --sage:         #3D9A6B;
+      /* Semantic tints */
+      --b-cinn-bg: #F9DDD9; --b-cinn-fg: #A83530;
+      --b-ox-bg:   #D0E0F3; --b-ox-fg:   #163A67;
+      --b-saff-bg: #FDF0D0; --b-saff-fg: #9E6012;
+      --b-sage-bg: #D0F0E0; --b-sage-fg: #1A6640;
+      --b-neu-bg:  #ECEAE4; --b-neu-fg:  #3D3935;
+      --b-drk-bg:  #1A1814; --b-drk-fg:  #FAFAF7;
+      --al-info-bg: #EEF3FA; --al-info-bd: #9DBDE6; --al-info-title: #163A67; --al-info-body: #1D4E89;
+      --al-ok-bg:   #E8F5EE; --al-ok-bd:   #8FCBA8; --al-ok-title:   #1A6640; --al-ok-body:   #3D9A6B;
+      --al-warn-bg: #FEF7E0; --al-warn-bd: #F4C460; --al-warn-title: #9E6012; --al-warn-body: #C88018;
+      --al-err-bg:  #FDF2F1; --al-err-bd:  #E88880; --al-err-title:  #871E1E; --al-err-body:  #C8463A;
+      --chart-grid: #ECEAE4;
+    }
+
+    html.dark {
+      --bg:           #0D0B09;
+      --bg-subtle:    #161310;
+      --surface:      #1E1A16;
+      --border-light: #272018;
+      --border:       #352C22;
+      --ink:          #EDE8E0;
+      --secondary:    #B5AFA6;
+      --muted:        #7A7470;
+      --dim:          #4E4844;
+      --stone:        #38302A;
+      --mid:          #CCC7C0;
+      --cinn:         #D95045;
+      --cinn-hover:   #E87060;
+      --ox:           #5A94CC;
+      --saff:         #E8A82A;
+      --sage:         #4DAA7B;
+      /* Semantic tints – dark mode */
+      --b-cinn-bg: rgba(217,80,69,0.16); --b-cinn-fg: #F07060;
+      --b-ox-bg:   rgba(90,148,204,0.16); --b-ox-fg:  #80B4E8;
+      --b-saff-bg: rgba(232,168,42,0.16); --b-saff-fg: #F0C050;
+      --b-sage-bg: rgba(77,170,123,0.16); --b-sage-fg: #5DBA8B;
+      --b-neu-bg:  rgba(60,48,34,0.6);    --b-neu-fg:  #C0BAB2;
+      --b-drk-bg:  #EDE8E0;               --b-drk-fg:  #1A1814;
+      --al-info-bg: rgba(90,148,204,0.08); --al-info-bd: rgba(90,148,204,0.3); --al-info-title: #80B4E8; --al-info-body: #5A94CC;
+      --al-ok-bg:   rgba(77,170,123,0.08); --al-ok-bd:   rgba(77,170,123,0.3); --al-ok-title:   #5DBA8B; --al-ok-body:   #4DAA7B;
+      --al-warn-bg: rgba(232,168,42,0.08); --al-warn-bd: rgba(232,168,42,0.3); --al-warn-title: #F0C050; --al-warn-body: #E8A82A;
+      --al-err-bg:  rgba(217,80,69,0.08);  --al-err-bd:  rgba(217,80,69,0.3);  --al-err-title:  #F07060; --al-err-body:  #D95045;
+      --chart-grid: #272018;
+    }
+
+    /* ══ Theme transition ═══════════════════════════════════════ */
+    *, *::before, *::after {
+      box-sizing: border-box;
+      transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+    }
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Jost', sans-serif;
+      background-color: var(--bg);
+      color: var(--ink);
+    }
+
+    /* Grain overlay */
+    body::after {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
+      opacity: 0.022;
+      pointer-events: none;
+      z-index: 9999;
+      transition: none;
+    }
+    html.dark body::after { opacity: 0.04; }
+
+    /* Scrollbar */
+    ::-webkit-scrollbar { width: 4px; }
+    ::-webkit-scrollbar-track { background: var(--bg-subtle); }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--dim); }
+
+    /* Selection */
+    ::selection { background: var(--cinn); color: var(--bg); }
+
+    /* ---- Sidebar ---- */
+    .sidebar {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      background: var(--bg-subtle);
+      border-right: 1px solid var(--border-light);
+    }
+    .sidebar::-webkit-scrollbar { width: 0; }
+
+    .nav-link {
+      position: relative;
+      display: flex;
+      align-items: center;
+      padding: 0.2rem 0 0.2rem 0.875rem;
+      font-size: 0.825rem;
+      color: var(--muted);
+      text-decoration: none;
+      border-left: 1.5px solid transparent;
+    }
+    .nav-link:hover { color: var(--cinn); }
+    .nav-link.active {
+      color: var(--cinn);
+      border-left-color: var(--cinn);
+      font-weight: 500;
+    }
+
+    /* ---- Section label ---- */
+    .section-label {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.68rem;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--cinn);
+    }
+
+    .section-rule {
+      width: 40px;
+      height: 2px;
+      background: var(--cinn);
+      margin: 0.9rem 0 1.5rem;
+    }
+
+    /* ---- Buttons ---- */
+    .btn {
+      font-family: 'Jost', sans-serif;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    /* ---- Inputs ---- */
+    .field {
+      width: 100%;
+      font-family: 'Jost', sans-serif;
+      font-size: 0.875rem;
+      color: var(--mid);
+      background: var(--surface);
+      border: 1.5px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 0.875rem;
+      transition: border-color 0.15s, box-shadow 0.15s, background 0.25s;
+      outline: none;
+    }
+    .field::placeholder { color: var(--stone); }
+    .field:focus {
+      border-color: var(--cinn);
+      box-shadow: 0 0 0 3px rgba(200, 70, 58, 0.12);
+    }
+    .field.success {
+      border-color: var(--sage);
+      box-shadow: 0 0 0 3px rgba(61, 154, 107, 0.12);
+    }
+    .field.error {
+      border-color: var(--cinn);
+      box-shadow: 0 0 0 3px rgba(200, 70, 58, 0.12);
+    }
+
+    /* ---- Toggle ---- */
+    .toggle { width: 42px; height: 22px; background: var(--border); border-radius: 11px; position: relative; cursor: pointer; transition: background 0.2s; flex-shrink: 0; }
+    .toggle.on { background: var(--cinn); }
+    .toggle-thumb { width: 16px; height: 16px; background: var(--surface); border-radius: 50%; position: absolute; top: 3px; left: 3px; transition: transform 0.2s; box-shadow: 0 1px 3px rgba(0,0,0,0.18); }
+    .toggle.on .toggle-thumb { transform: translateX(20px); }
+
+    /* ---- Card ---- */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border-light);
+      border-radius: 12px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.25s, border-color 0.25s;
+    }
+    .card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 24px rgba(0,0,0,0.1);
+    }
+    html.dark .card { box-shadow: 0 1px 4px rgba(0,0,0,0.3); }
+    html.dark .card:hover { box-shadow: 0 6px 24px rgba(0,0,0,0.4); }
+
+    /* ---- Badge ---- */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-family: 'Jost', sans-serif;
+      font-size: 0.7rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      border-radius: 4px;
+      padding: 2px 8px;
+      white-space: nowrap;
+    }
+
+    /* ---- Progress bar ---- */
+    .progress { height: 4px; background: var(--border); border-radius: 2px; overflow: hidden; }
+    .progress-fill { height: 100%; border-radius: 2px; transition: width 0.8s ease; }
+
+    /* ---- Hero underline animation ---- */
+    @keyframes line-in { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+    .underline-anim { position: relative; display: inline-block; }
+    .underline-anim::after {
+      content: '';
+      position: absolute;
+      bottom: 6px;
+      left: 0; right: 0;
+      height: 3px;
+      background: var(--cinn);
+      transform-origin: left;
+      animation: line-in 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.6s both;
+      transition: none;
+    }
+
+    /* ---- Color swatch ---- */
+    .swatch { transition: transform 0.18s; }
+    .swatch:hover { transform: translateY(-3px); }
+
+    /* ---- Code block ---- */
+    pre {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.78rem;
+      line-height: 1.7;
+      background: #13110F;
+      color: #E0DDD6;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      transition: none;
+    }
+    .tok-c  { color: #888480; }
+    .tok-k  { color: #E8A020; }
+    .tok-s  { color: #88C692; }
+    .tok-n  { color: #6BAEE6; }
+    .tok-p  { color: #E88880; }
+
+    /* ---- Table ---- */
+    table { border-collapse: collapse; width: 100%; }
+    th {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.68rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--dim);
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    td {
+      padding: 0.875rem 1rem;
+      font-size: 0.875rem;
+      border-bottom: 1px solid var(--border-light);
+      transition: background 0.25s;
+    }
+    tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: var(--bg-subtle); }
+
+    /* ---- Stat number ---- */
+    .stat-num {
+      font-family: 'Cormorant', serif;
+      font-size: 3rem;
+      font-weight: 300;
+      line-height: 1;
+    }
+
+    /* ---- Alert ---- */
+    .alert {
+      display: flex;
+      gap: 0.75rem;
+      padding: 1rem;
+      border-radius: 8px;
+      border: 1px solid;
+    }
+  </style>
+</head>
+<body>
+<div class="flex min-h-screen">
+
+  <!-- ═══════════════════════════════════════
+       SIDEBAR
+  ═══════════════════════════════════════ -->
+  <aside class="sidebar w-56 flex-shrink-0 px-5 py-8 flex flex-col">
+
+    <!-- Logotype -->
+    <div class="mb-9">
+      <div class="flex items-center gap-2.5 mb-0.5">
+        <div class="w-6 h-6 bg-cinnabar-500 rounded flex items-center justify-center flex-shrink-0">
+          <span style="font-family:'Cormorant',serif;color:#FAFAF7;font-size:15px;font-weight:700;line-height:1;">L</span>
+        </div>
+        <span style="font-family:'Cormorant',serif;font-size:1.15rem;font-weight:600;letter-spacing:0.08em;color:var(--ink);">LUMINA</span>
+      </div>
+      <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);letter-spacing:0.12em;padding-left:34px;">v1.0 · Tailwind CSS</p>
+    </div>
+
+    <!-- Nav -->
+    <nav class="flex-1 space-y-5">
+      <div>
+        <p class="section-label pl-3.5 mb-2">Foundation</p>
+        <a href="#colors"     class="nav-link">Colors</a>
+        <a href="#typography" class="nav-link">Typography</a>
+      </div>
+      <div>
+        <p class="section-label pl-3.5 mb-2">Components</p>
+        <a href="#buttons"    class="nav-link">Buttons</a>
+        <a href="#forms"      class="nav-link">Form Controls</a>
+        <a href="#cards"      class="nav-link">Cards</a>
+        <a href="#badges"     class="nav-link">Badges</a>
+        <a href="#alerts"     class="nav-link">Alerts</a>
+        <a href="#tables"     class="nav-link">Tables</a>
+      </div>
+      <div>
+        <p class="section-label pl-3.5 mb-2">Patterns</p>
+        <a href="#stats"      class="nav-link">Stats & Data</a>
+        <a href="#graphs"     class="nav-link">Charts & Graphs</a>
+        <a href="#code"       class="nav-link">Code</a>
+      </div>
+    </nav>
+
+    <!-- Footer: progress + dark mode toggle -->
+    <div class="mt-auto" style="display:flex;flex-direction:column;gap:12px;">
+      <div style="border-radius:8px;padding:12px;border:1px solid var(--border-light);background:var(--border-light);">
+        <div class="progress mb-1.5">
+          <div class="progress-fill bg-cinnabar-500" style="width:85%;"></div>
+        </div>
+        <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);">85% documented</p>
+      </div>
+      <!-- Theme toggle -->
+      <button id="theme-toggle" onclick="toggleTheme()" style="display:flex;align-items:center;justify-content:space-between;width:100%;padding:9px 12px;border-radius:8px;border:1px solid var(--border-light);background:var(--border-light);cursor:pointer;transition:background 0.2s,border-color 0.2s;">
+        <span id="theme-label" style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);letter-spacing:0.08em;">LIGHT MODE</span>
+        <span id="theme-icon" style="font-size:14px;">☀️</span>
+      </button>
+    </div>
+  </aside>
+
+  <!-- ═══════════════════════════════════════
+       MAIN
+  ═══════════════════════════════════════ -->
+  <main class="flex-1 overflow-auto">
+
+    <!-- ── HERO ── -->
+    <section class="px-14 pt-16 pb-14" style="background:linear-gradient(140deg,var(--bg) 50%,var(--bg-subtle) 100%);border-bottom:1px solid var(--border-light);">
+      <p class="section-label mb-5">Design System</p>
+      <h1 style="font-family:'Cormorant',serif;font-size:5.5rem;font-weight:300;line-height:0.93;color:var(--ink);margin-bottom:1.5rem;">
+        Built with<br>
+        <em class="underline-anim" style="color:#C8463A;font-weight:400;">intention</em>
+      </h1>
+      <p style="font-size:1rem;font-weight:300;color:var(--muted);max-width:460px;line-height:1.75;margin-bottom:2rem;">
+        A warm, editorial system for applications that value clarity, craft, and considered aesthetics. Every token, every component — deliberate.
+      </p>
+      <div class="flex gap-3">
+        <button class="btn bg-cinnabar-500 text-cream-50 text-sm px-5 py-2.5 rounded-md hover:bg-cinnabar-600" style="box-shadow:0 2px 8px rgba(200,70,58,0.3);">
+          Get Started
+        </button>
+        <button class="btn border border-cream-300 text-cream-700 text-sm px-5 py-2.5 rounded-md hover:bg-cream-100 hover:border-cream-400">
+          View on GitHub
+        </button>
+      </div>
+    </section>
+
+    <div class="px-14 py-12" style="max-width:900px;">
+
+
+      <!-- ══════════════════════════════════
+           01 · COLORS
+      ══════════════════════════════════ -->
+      <section id="colors" class="mb-20 scroll-mt-6">
+        <p class="section-label">01 — Foundation</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Colors</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">A warm, grounded palette drawn from natural materials and editorial print design.</p>
+
+        <!-- Neutrals -->
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Neutral Scale</p>
+        <div style="display:grid;grid-template-columns:repeat(9,1fr);gap:8px;margin-bottom:2.5rem;">
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#FAFAF7;border:1px solid #ECEAE4;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">50</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#FAFAF7</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:var(--bg-subtle);"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">100</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#F4F4EF</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:var(--border-light);"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">200</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#ECEAE4</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#E0DDD6;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">300</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#E0DDD6</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#A8A49B;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">500</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#A8A49B</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#888480;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">600</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#888480</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#645F5A;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">700</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#645F5A</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#3D3935;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">800</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#3D3935</p>
+            </div>
+          </div>
+          <div class="swatch">
+            <div style="height:48px;border-radius:6px 6px 0 0;background:#1A1814;"></div>
+            <div style="background:var(--bg-subtle);border-radius:0 0 6px 6px;padding:6px 8px;border:1px solid #ECEAE4;border-top:none;">
+              <p style="font-family:'Fira Code',monospace;font-size:0.6rem;color:var(--muted);">900</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);">#1A1814</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Accent palettes -->
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Accent Palettes</p>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:2.5rem;">
+
+          <!-- Cinnabar -->
+          <div style="border-radius:10px;overflow:hidden;border:1px solid #ECEAE4;">
+            <div style="height:72px;background:linear-gradient(135deg,#E88880,#C8463A,#641E1E);"></div>
+            <div style="background:var(--bg-subtle);padding:14px;">
+              <p style="font-size:0.875rem;font-weight:500;color:var(--ink);margin-bottom:8px;">Cinnabar</p>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;margin-bottom:4px;">
+                <span style="color:var(--dim);">200</span><span style="color:var(--muted);">#F2B5AF</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;margin-bottom:4px;">
+                <span style="color:var(--dim);">500</span><span style="color:#C8463A;">#C8463A</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;">
+                <span style="color:var(--dim);">700</span><span style="color:var(--muted);">#872828</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Oxford -->
+          <div style="border-radius:10px;overflow:hidden;border:1px solid #ECEAE4;">
+            <div style="height:72px;background:linear-gradient(135deg,#6498D3,#1D4E89,#060E1C);"></div>
+            <div style="background:var(--bg-subtle);padding:14px;">
+              <p style="font-size:0.875rem;font-weight:500;color:var(--ink);margin-bottom:8px;">Oxford</p>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;margin-bottom:4px;">
+                <span style="color:var(--dim);">200</span><span style="color:var(--muted);">#9DBDE6</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;margin-bottom:4px;">
+                <span style="color:var(--dim);">500</span><span style="color:#1D4E89;">#1D4E89</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;">
+                <span style="color:var(--dim);">700</span><span style="color:var(--muted);">#102D52</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Saffron -->
+          <div style="border-radius:10px;overflow:hidden;border:1px solid #ECEAE4;">
+            <div style="height:72px;background:linear-gradient(135deg,#F4C460,#E8A020,#4A2506);"></div>
+            <div style="background:var(--bg-subtle);padding:14px;">
+              <p style="font-size:0.875rem;font-weight:500;color:var(--ink);margin-bottom:8px;">Saffron</p>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;margin-bottom:4px;">
+                <span style="color:var(--dim);">200</span><span style="color:var(--muted);">#F9DC98</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;margin-bottom:4px;">
+                <span style="color:var(--dim);">500</span><span style="color:#C88018;">#E8A020</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-family:'Fira Code',monospace;font-size:0.68rem;">
+                <span style="color:var(--dim);">700</span><span style="color:var(--muted);">#9E6012</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Semantic -->
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Semantic Tokens</p>
+        <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px;">
+          <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;border:1px solid #ECEAE4;background:var(--surface);">
+            <div style="width:28px;height:28px;border-radius:6px;background:#3D9A6B;flex-shrink:0;"></div>
+            <div>
+              <p style="font-size:0.75rem;font-weight:500;color:var(--ink);">Success</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.62rem;color:var(--dim);">#3D9A6B</p>
+            </div>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;border:1px solid #ECEAE4;background:var(--surface);">
+            <div style="width:28px;height:28px;border-radius:6px;background:#E8A020;flex-shrink:0;"></div>
+            <div>
+              <p style="font-size:0.75rem;font-weight:500;color:var(--ink);">Warning</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.62rem;color:var(--dim);">#E8A020</p>
+            </div>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;border:1px solid #ECEAE4;background:var(--surface);">
+            <div style="width:28px;height:28px;border-radius:6px;background:#C8463A;flex-shrink:0;"></div>
+            <div>
+              <p style="font-size:0.75rem;font-weight:500;color:var(--ink);">Error</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.62rem;color:var(--dim);">#C8463A</p>
+            </div>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;border:1px solid #ECEAE4;background:var(--surface);">
+            <div style="width:28px;height:28px;border-radius:6px;background:#1D4E89;flex-shrink:0;"></div>
+            <div>
+              <p style="font-size:0.75rem;font-weight:500;color:var(--ink);">Info</p>
+              <p style="font-family:'Fira Code',monospace;font-size:0.62rem;color:var(--dim);">#1D4E89</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           02 · TYPOGRAPHY
+      ══════════════════════════════════ -->
+      <section id="typography" class="mb-20 scroll-mt-6">
+        <p class="section-label">02 — Foundation</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Typography</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Three typefaces, each with a distinct role: Cormorant for display, Jost for UI, Fira Code for data.</p>
+
+        <!-- Typeface specimens -->
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:3rem;">
+          <div style="padding:24px;background:var(--bg-subtle);border-radius:10px;border:1px solid #ECEAE4;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:10px;letter-spacing:0.12em;">DISPLAY</p>
+            <p style="font-family:'Cormorant',serif;font-size:2.2rem;font-weight:400;line-height:1;color:var(--ink);margin-bottom:4px;">Cormorant</p>
+            <p style="font-family:'Cormorant',serif;font-size:1rem;font-style:italic;color:var(--muted);margin-bottom:16px;">for headings & display</p>
+            <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);line-height:1.8;">ABCDEFGHIJKLM<br>NOPQRSTUVWXYZ<br>abcdefghijklm<br>nopqrstuvwxyz<br>0123456789</p>
+          </div>
+          <div style="padding:24px;background:var(--bg-subtle);border-radius:10px;border:1px solid #ECEAE4;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:10px;letter-spacing:0.12em;">UI SANS</p>
+            <p style="font-family:'Jost',sans-serif;font-size:2.2rem;font-weight:400;line-height:1;color:var(--ink);margin-bottom:4px;">Jost</p>
+            <p style="font-family:'Jost',sans-serif;font-size:1rem;font-weight:300;color:var(--muted);margin-bottom:16px;">for interfaces & body</p>
+            <p style="font-family:'Jost',sans-serif;font-size:0.7rem;color:var(--stone);line-height:1.8;">ABCDEFGHIJKLM<br>NOPQRSTUVWXYZ<br>abcdefghijklm<br>nopqrstuvwxyz<br>0123456789</p>
+          </div>
+          <div style="padding:24px;background:var(--bg-subtle);border-radius:10px;border:1px solid #ECEAE4;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:10px;letter-spacing:0.12em;">MONOSPACE</p>
+            <p style="font-family:'Fira Code',monospace;font-size:1.8rem;font-weight:400;line-height:1;color:var(--ink);margin-bottom:4px;">Fira Code</p>
+            <p style="font-family:'Fira Code',monospace;font-size:0.8rem;color:var(--muted);margin-bottom:16px;">for code & labels</p>
+            <p style="font-family:'Fira Code',monospace;font-size:0.58rem;color:var(--stone);line-height:1.8;">ABCDEFGHIJKLM<br>NOPQRSTUVWXYZ<br>abcdefghijklm<br>nopqrstuvwxyz<br>0123456789</p>
+          </div>
+        </div>
+
+        <!-- Display scale -->
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1.25rem;">Display Scale</p>
+        <div style="border-left:2px solid #ECEAE4;padding-left:1.5rem;margin-bottom:2.5rem;">
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1.25rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">D1 / 5xl</span>
+            <p style="font-family:'Cormorant',serif;font-size:4.5rem;font-weight:300;line-height:1;color:var(--ink);">The quick fox</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1.25rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">D2 / 4xl</span>
+            <p style="font-family:'Cormorant',serif;font-size:3rem;font-weight:400;line-height:1.1;color:var(--ink);">The quick brown fox</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1.25rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">H1 / 3xl</span>
+            <p style="font-family:'Cormorant',serif;font-size:2.25rem;font-weight:500;line-height:1.2;color:var(--ink);">The quick brown fox jumps</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">H2 / 2xl</span>
+            <p style="font-family:'Cormorant',serif;font-size:1.75rem;font-weight:600;line-height:1.25;color:var(--ink);">The quick brown fox jumps over the lazy dog</p>
+          </div>
+        </div>
+
+        <!-- UI scale -->
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1.25rem;">UI Scale</p>
+        <div style="border-left:2px solid #ECEAE4;padding-left:1.5rem;">
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">lg / 18px</span>
+            <p style="font-size:1.125rem;font-weight:400;color:var(--ink);">The quick brown fox jumps over the lazy dog.</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">base / 16px</span>
+            <p style="font-size:1rem;color:var(--ink);">The quick brown fox jumps over the lazy dog.</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">sm / 14px</span>
+            <p style="font-size:0.875rem;color:var(--secondary);">The quick brown fox jumps over the lazy dog.</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;margin-bottom:1rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">xs / 12px</span>
+            <p style="font-size:0.75rem;color:var(--muted);">The quick brown fox jumps over the lazy dog.</p>
+          </div>
+          <div style="display:flex;align-items:baseline;gap:1.5rem;">
+            <span style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);width:56px;flex-shrink:0;">label</span>
+            <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.2em;text-transform:uppercase;color:#C8463A;">Category Label</p>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           03 · BUTTONS
+      ══════════════════════════════════ -->
+      <section id="buttons" class="mb-20 scroll-mt-6">
+        <p class="section-label">03 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Buttons</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Clear hierarchy across variants and sizes. The primary action always wins attention.</p>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Variants</p>
+        <div style="display:flex;flex-wrap:wrap;gap:12px;margin-bottom:2.5rem;align-items:center;">
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600" style="box-shadow:0 2px 6px rgba(200,70,58,0.25);">Primary</button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cinnabar-500 hover:bg-cinnabar-50" style="border:1.5px solid #C8463A;">Secondary</button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-700 hover:bg-cream-100">Ghost</button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-50 bg-oxford-500 hover:bg-oxford-600" style="box-shadow:0 2px 6px rgba(29,78,137,0.25);">Oxford</button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-400" style="border:1.5px solid #E0DDD6;" disabled>Disabled</button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-50 bg-cinnabar-500" style="box-shadow:0 2px 6px rgba(200,70,58,0.25);gap:8px;">
+            <svg style="width:14px;height:14px;animation:spin 1s linear infinite;" fill="none" viewBox="0 0 24 24"><circle style="opacity:0.25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path style="opacity:0.75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/></svg>
+            Loading
+          </button>
+        </div>
+        <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Sizes</p>
+        <div style="display:flex;flex-wrap:wrap;gap:12px;margin-bottom:2.5rem;align-items:center;">
+          <button class="btn rounded text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600" style="font-size:0.7rem;padding:5px 12px;">XSmall</button>
+          <button class="btn rounded-md text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600 text-xs px-4 py-2">Small</button>
+          <button class="btn rounded-md text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600 text-sm px-5 py-2.5">Medium</button>
+          <button class="btn rounded-lg text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600 text-base px-6 py-3">Large</button>
+          <button class="btn rounded-lg text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600 px-8 py-4" style="font-family:'Cormorant',serif;font-size:1.3rem;font-style:italic;">X-Large</button>
+        </div>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">With Icons</p>
+        <div style="display:flex;flex-wrap:wrap;gap:12px;align-items:center;">
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600" style="gap:8px;box-shadow:0 2px 6px rgba(200,70,58,0.25);">
+            <svg style="width:16px;height:16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+            Add Route
+          </button>
+          <button class="btn text-sm px-5 py-2.5 rounded-md text-cream-700 hover:bg-cream-100" style="gap:8px;border:1px solid #E0DDD6;">
+            <svg style="width:16px;height:16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+            Export CSV
+          </button>
+          <button class="btn text-cream-600 hover:bg-cream-100 rounded-md" style="padding:10px;">
+            <svg style="width:18px;height:18px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/></svg>
+          </button>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           04 · FORM CONTROLS
+      ══════════════════════════════════ -->
+      <section id="forms" class="mb-20 scroll-mt-6">
+        <p class="section-label">04 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Form Controls</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Inputs that respect the user's attention with clear states and minimal chrome.</p>
+
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:32px;">
+          <!-- Left -->
+          <div style="display:flex;flex-direction:column;gap:20px;">
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:6px;letter-spacing:0.05em;">Full Name</label>
+              <input type="text" placeholder="Eleanor Whitmore" class="field">
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:6px;letter-spacing:0.05em;">Email — Valid</label>
+              <div style="position:relative;">
+                <input type="email" value="e.whitmore@lumina.co" class="field success" style="padding-right:2.5rem;">
+                <svg style="position:absolute;right:12px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:#3D9A6B;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              </div>
+              <p style="font-size:0.72rem;color:#3D9A6B;margin-top:4px;">Verified and valid.</p>
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:6px;letter-spacing:0.05em;">Username — Error</label>
+              <input type="text" value="eleanor w" class="field error">
+              <p style="font-size:0.72rem;color:#C8463A;margin-top:4px;">Spaces are not allowed in usernames.</p>
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:6px;letter-spacing:0.05em;">Biography</label>
+              <textarea rows="4" placeholder="Tell us about yourself…" class="field" style="resize:none;"></textarea>
+              <p style="font-size:0.68rem;color:var(--stone);text-align:right;margin-top:3px;">0 / 280</p>
+            </div>
+          </div>
+
+          <!-- Right -->
+          <div style="display:flex;flex-direction:column;gap:20px;">
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:6px;letter-spacing:0.05em;">Role</label>
+              <div style="position:relative;">
+                <select class="field" style="appearance:none;padding-right:2.5rem;cursor:pointer;">
+                  <option>Designer</option>
+                  <option>Developer</option>
+                  <option>Product Manager</option>
+                </select>
+                <svg style="position:absolute;right:12px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:var(--dim);pointer-events:none;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+              </div>
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:10px;letter-spacing:0.05em;">Notifications</label>
+              <div style="display:flex;flex-direction:column;gap:8px;">
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="checkbox" checked style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Email notifications</span>
+                </label>
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="checkbox" style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Push notifications</span>
+                </label>
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="checkbox" checked style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Weekly digest</span>
+                </label>
+              </div>
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:10px;letter-spacing:0.05em;">Plan</label>
+              <div style="display:flex;flex-direction:column;gap:8px;">
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="radio" name="plan" checked style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Free</span>
+                </label>
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="radio" name="plan" style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Pro — $12/mo</span>
+                </label>
+                <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                  <input type="radio" name="plan" style="width:16px;height:16px;accent-color:#C8463A;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Team — $49/mo</span>
+                </label>
+              </div>
+            </div>
+            <div>
+              <label style="display:block;font-size:0.72rem;font-weight:500;color:var(--muted);margin-bottom:10px;letter-spacing:0.05em;">Quick Settings</label>
+              <div style="display:flex;flex-direction:column;gap:12px;">
+                <div style="display:flex;align-items:center;justify-content:space-between;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Dark mode</span>
+                  <div class="toggle" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+                </div>
+                <div style="display:flex;align-items:center;justify-content:space-between;">
+                  <span style="font-size:0.875rem;color:var(--mid);">Analytics</span>
+                  <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+                </div>
+                <div style="display:flex;align-items:center;justify-content:space-between;">
+                  <span style="font-size:0.875rem;color:var(--stone);">Beta features</span>
+                  <div class="toggle" style="opacity:0.45;cursor:not-allowed;"><div class="toggle-thumb"></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           05 · CARDS
+      ══════════════════════════════════ -->
+      <section id="cards" class="mb-20 scroll-mt-6">
+        <p class="section-label">05 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Cards</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Containers that group related content with consistent rhythm and typographic hierarchy.</p>
+
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;">
+          <!-- Feature card -->
+          <div class="card" style="padding:20px;">
+            <div style="width:34px;height:34px;border-radius:8px;background:#F2B5AF;display:flex;align-items:center;justify-content:center;margin-bottom:14px;">
+              <svg style="width:16px;height:16px;color:#C8463A;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+            </div>
+            <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:6px;">Real-time Tracking</h4>
+            <p style="font-size:0.8rem;color:var(--muted);line-height:1.65;">Monitor vehicle positions and schedule adherence across all routes simultaneously.</p>
+          </div>
+
+          <!-- Media card -->
+          <div class="card" style="overflow:hidden;">
+            <div style="height:120px;background:linear-gradient(135deg,#C8463A 0%,#1D4E89 100%);"></div>
+            <div style="padding:16px;">
+              <span class="badge" style="background:#F9DDD9;color:#871E1E;margin-bottom:10px;">Transit</span>
+              <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:6px;">Route Optimization</h4>
+              <p style="font-size:0.8rem;color:var(--muted);">Data-driven insights for scheduling improvements.</p>
+            </div>
+          </div>
+
+          <!-- Profile card -->
+          <div class="card" style="padding:20px;">
+            <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+              <div style="width:40px;height:40px;border-radius:50%;background:linear-gradient(135deg,#C8463A,#1D4E89);display:flex;align-items:center;justify-content:center;color:#FAFAF7;font-size:0.8rem;font-weight:500;flex-shrink:0;">EW</div>
+              <div>
+                <p style="font-size:0.875rem;font-weight:500;color:var(--ink);">Eleanor Whitmore</p>
+                <p style="font-size:0.72rem;color:var(--dim);">Senior Analyst</p>
+              </div>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:6px;">
+              <div style="display:flex;justify-content:space-between;font-size:0.75rem;">
+                <span style="color:var(--dim);">Routes audited</span>
+                <span style="font-family:'Fira Code',monospace;color:var(--mid);">142</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-size:0.75rem;">
+                <span style="color:var(--dim);">Reports filed</span>
+                <span style="font-family:'Fira Code',monospace;color:var(--mid);">38</span>
+              </div>
+              <div style="display:flex;justify-content:space-between;font-size:0.75rem;">
+                <span style="color:var(--dim);">Joined</span>
+                <span style="font-family:'Fira Code',monospace;color:var(--mid);">Mar 2023</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Action card (spans 2) -->
+          <div class="card" style="padding:20px;grid-column:span 2;">
+            <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:16px;">
+              <div>
+                <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:4px;">Upgrade to Pro</h4>
+                <p style="font-size:0.8rem;color:var(--muted);">Unlock advanced analytics and team collaboration features.</p>
+              </div>
+              <span class="badge" style="background:var(--b-saff-bg);color:var(--b-saff-fg);">Pro</span>
+            </div>
+            <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:16px;">
+              <div style="text-align:center;padding:12px;background:var(--bg-subtle);border-radius:8px;">
+                <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:3px;">Seats</p>
+                <p style="font-size:0.875rem;font-weight:500;color:var(--ink);">Unlimited</p>
+              </div>
+              <div style="text-align:center;padding:12px;background:var(--bg-subtle);border-radius:8px;">
+                <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:3px;">Storage</p>
+                <p style="font-size:0.875rem;font-weight:500;color:var(--ink);">100 GB</p>
+              </div>
+              <div style="text-align:center;padding:12px;background:var(--bg-subtle);border-radius:8px;">
+                <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:3px;">Support</p>
+                <p style="font-size:0.875rem;font-weight:500;color:var(--ink);">Priority</p>
+              </div>
+            </div>
+            <button class="btn w-full text-cream-50 bg-cinnabar-500 hover:bg-cinnabar-600 text-sm py-2.5 rounded-md" style="box-shadow:0 2px 8px rgba(200,70,58,0.25);">
+              Upgrade to Pro — $49/mo
+            </button>
+          </div>
+
+          <!-- Stat card -->
+          <div class="card" style="padding:20px;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:6px;">On-Time Rate</p>
+            <div class="stat-num" style="color:#3D9A6B;margin-bottom:6px;">87<span style="font-size:1.5rem;color:var(--dim);">%</span></div>
+            <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">
+              <span class="badge" style="background:var(--b-sage-bg);color:var(--b-sage-fg);">↑ 2.1%</span>
+              <span style="font-size:0.72rem;color:var(--dim);">vs last week</span>
+            </div>
+            <div class="progress">
+              <div class="progress-fill" style="width:87%;background:#3D9A6B;"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           06 · BADGES
+      ══════════════════════════════════ -->
+      <section id="badges" class="mb-20 scroll-mt-6">
+        <p class="section-label">06 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Badges</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Compact labels for status, categories, and metadata. Restrained by default.</p>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Color Variants</p>
+        <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:2rem;">
+          <span class="badge" style="background:var(--b-cinn-bg);color:var(--b-cinn-fg);">Cinnabar</span>
+          <span class="badge" style="background:var(--b-ox-bg);color:var(--b-ox-fg);">Oxford</span>
+          <span class="badge" style="background:var(--b-saff-bg);color:var(--b-saff-fg);">Saffron</span>
+          <span class="badge" style="background:var(--b-sage-bg);color:var(--b-sage-fg);">Success</span>
+          <span class="badge" style="background:var(--border-light);color:var(--mid);">Neutral</span>
+          <span class="badge" style="background:var(--b-drk-bg);color:var(--b-drk-fg);">Dark</span>
+        </div>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Status with Indicator</p>
+        <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:2rem;">
+          <span class="badge" style="background:var(--b-sage-bg);color:var(--b-sage-fg);">
+            <span style="width:6px;height:6px;border-radius:50%;background:#3D9A6B;display:inline-block;"></span>
+            Active
+          </span>
+          <span class="badge" style="background:var(--b-saff-bg);color:var(--b-saff-fg);">
+            <span style="width:6px;height:6px;border-radius:50%;background:#E8A020;display:inline-block;"></span>
+            Pending
+          </span>
+          <span class="badge" style="background:var(--b-cinn-bg);color:var(--b-cinn-fg);">
+            <span style="width:6px;height:6px;border-radius:50%;background:#C8463A;display:inline-block;"></span>
+            Delayed
+          </span>
+          <span class="badge" style="background:var(--border-light);color:var(--secondary);">
+            <span style="width:6px;height:6px;border-radius:50%;background:#A8A49B;display:inline-block;"></span>
+            Archived
+          </span>
+        </div>
+
+        <p style="font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--dim);margin-bottom:1rem;">Sizes</p>
+        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
+          <span style="font-family:'Fira Code',monospace;font-size:0.58rem;padding:1px 6px;border-radius:3px;background:var(--b-cinn-bg);color:var(--b-cinn-fg);">xs</span>
+          <span class="badge" style="font-size:0.68rem;background:var(--b-cinn-bg);color:var(--b-cinn-fg);">Small</span>
+          <span class="badge" style="font-size:0.75rem;padding:3px 10px;background:var(--b-cinn-bg);color:var(--b-cinn-fg);">Medium</span>
+          <span style="font-family:'Jost',sans-serif;font-size:0.875rem;font-weight:500;padding:5px 14px;border-radius:6px;background:var(--b-cinn-bg);color:var(--b-cinn-fg);">Large</span>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           07 · ALERTS
+      ══════════════════════════════════ -->
+      <section id="alerts" class="mb-20 scroll-mt-6">
+        <p class="section-label">07 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Alerts</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">System feedback that demands proportionate attention. Each severity is visually unambiguous.</p>
+
+        <div style="display:flex;flex-direction:column;gap:12px;">
+          <!-- Info -->
+          <div class="alert" style="background:var(--al-info-bg);border-color:var(--al-info-bd);">
+            <svg style="width:18px;height:18px;flex-shrink:0;margin-top:1px;color:#1D4E89;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <div>
+              <p style="font-size:0.875rem;font-weight:500;color:var(--al-info-title);margin-bottom:2px;">Scheduled Maintenance</p>
+              <p style="font-size:0.82rem;color:var(--al-info-body);">The system will be unavailable Sunday from 2–4 AM UTC for database upgrades.</p>
+            </div>
+          </div>
+
+          <!-- Success -->
+          <div class="alert" style="background:var(--al-ok-bg);border-color:var(--al-ok-bd);">
+            <svg style="width:18px;height:18px;flex-shrink:0;margin-top:1px;color:#3D9A6B;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <div>
+              <p style="font-size:0.875rem;font-weight:500;color:var(--al-ok-title);margin-bottom:2px;">GTFS Feed Updated</p>
+              <p style="font-size:0.82rem;color:var(--al-ok-body);">Route schedules have been synchronized with the latest feed from the transit authority.</p>
+            </div>
+          </div>
+
+          <!-- Warning -->
+          <div class="alert" style="background:var(--al-warn-bg);border-color:var(--al-warn-bd);">
+            <svg style="width:18px;height:18px;flex-shrink:0;margin-top:1px;color:#C88018;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+            <div>
+              <p style="font-size:0.875rem;font-weight:500;color:var(--al-warn-title);margin-bottom:2px;">High Delay Alert — Line 9</p>
+              <p style="font-size:0.82rem;color:var(--al-warn-body);">Average delay on the Northshore line has exceeded 8 minutes for the past hour.</p>
+            </div>
+          </div>
+
+          <!-- Error -->
+          <div class="alert" style="background:var(--al-err-bg);border-color:var(--al-err-bd);">
+            <svg style="width:18px;height:18px;flex-shrink:0;margin-top:1px;color:#C8463A;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <div style="flex:1;">
+              <p style="font-size:0.875rem;font-weight:500;color:var(--al-err-title);margin-bottom:2px;">Feed Ingestion Failed</p>
+              <p style="font-size:0.82rem;color:var(--al-err-body);">Could not connect to the GTFS-RT endpoint. Last successful update was 47 minutes ago.</p>
+            </div>
+            <button style="font-size:0.8rem;font-weight:500;color:#C8463A;flex-shrink:0;cursor:pointer;white-space:nowrap;">Retry →</button>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           08 · TABLES
+      ══════════════════════════════════ -->
+      <section id="tables" class="mb-20 scroll-mt-6">
+        <p class="section-label">08 — Components</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Tables</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Dense data presented with precision. Minimal chrome, maximum legibility.</p>
+
+        <div style="background:var(--surface);border-radius:12px;border:1px solid #ECEAE4;box-shadow:0 1px 4px rgba(26,24,20,0.05);overflow:hidden;">
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid #F4F4EF;">
+            <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);">Route Performance</h4>
+            <div style="display:flex;gap:8px;">
+              <button class="btn text-xs px-3 py-1.5 rounded text-cream-600 hover:bg-cream-50" style="border:1px solid #ECEAE4;">Filter</button>
+              <button class="btn text-xs px-3 py-1.5 rounded text-cream-600 hover:bg-cream-50" style="border:1px solid #ECEAE4;">Export</button>
+            </div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Route</th>
+                <th>Direction</th>
+                <th>On-Time %</th>
+                <th>Avg. Delay</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <div style="display:flex;align-items:center;gap:10px;">
+                    <div style="width:28px;height:28px;border-radius:50%;background:#D0F0E0;display:flex;align-items:center;justify-content:center;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;color:#1A6640;flex-shrink:0;">7W</div>
+                    <div>
+                      <p style="font-size:0.85rem;font-weight:500;color:var(--ink);">Line 7</p>
+                      <p style="font-size:0.7rem;color:var(--dim);">Westbound</p>
+                    </div>
+                  </div>
+                </td>
+                <td style="font-size:0.8rem;color:var(--secondary);">Downtown → Harbour</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;font-weight:500;color:#3D9A6B;">94%</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;color:var(--muted);">1.2m</td>
+                <td><span class="badge" style="background:var(--b-sage-bg);color:var(--b-sage-fg);">On Track</span></td>
+                <td><button style="font-size:0.75rem;color:var(--dim);cursor:pointer;">View →</button></td>
+              </tr>
+              <tr>
+                <td>
+                  <div style="display:flex;align-items:center;gap:10px;">
+                    <div style="width:28px;height:28px;border-radius:50%;background:#D0E0F3;display:flex;align-items:center;justify-content:center;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;color:#163A67;flex-shrink:0;">2C</div>
+                    <div>
+                      <p style="font-size:0.85rem;font-weight:500;color:var(--ink);">Line 2</p>
+                      <p style="font-size:0.7rem;color:var(--dim);">Central</p>
+                    </div>
+                  </div>
+                </td>
+                <td style="font-size:0.8rem;color:var(--secondary);">University → Market</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;font-weight:500;color:#3D9A6B;">87%</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;color:var(--muted);">2.8m</td>
+                <td><span class="badge" style="background:var(--b-sage-bg);color:var(--b-sage-fg);">On Track</span></td>
+                <td><button style="font-size:0.75rem;color:var(--dim);cursor:pointer;">View →</button></td>
+              </tr>
+              <tr>
+                <td>
+                  <div style="display:flex;align-items:center;gap:10px;">
+                    <div style="width:28px;height:28px;border-radius:50%;background:#FDF0D0;display:flex;align-items:center;justify-content:center;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;color:#9E6012;flex-shrink:0;">14</div>
+                    <div>
+                      <p style="font-size:0.85rem;font-weight:500;color:var(--ink);">Line 14</p>
+                      <p style="font-size:0.7rem;color:var(--dim);">Airport Express</p>
+                    </div>
+                  </div>
+                </td>
+                <td style="font-size:0.8rem;color:var(--secondary);">Terminal 1 → Downtown</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;font-weight:500;color:#C88018;">71%</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;color:var(--muted);">5.4m</td>
+                <td><span class="badge" style="background:var(--b-saff-bg);color:var(--b-saff-fg);">Minor Delay</span></td>
+                <td><button style="font-size:0.75rem;color:var(--dim);cursor:pointer;">View →</button></td>
+              </tr>
+              <tr>
+                <td>
+                  <div style="display:flex;align-items:center;gap:10px;">
+                    <div style="width:28px;height:28px;border-radius:50%;background:#F9DDD9;display:flex;align-items:center;justify-content:center;font-family:'Fira Code',monospace;font-size:0.68rem;font-weight:500;color:#871E1E;flex-shrink:0;">9N</div>
+                    <div>
+                      <p style="font-size:0.85rem;font-weight:500;color:var(--ink);">Line 9</p>
+                      <p style="font-size:0.7rem;color:var(--dim);">Northshore</p>
+                    </div>
+                  </div>
+                </td>
+                <td style="font-size:0.8rem;color:var(--secondary);">Northshore → City Hall</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;font-weight:500;color:#C8463A;">58%</td>
+                <td style="font-family:'Fira Code',monospace;font-size:0.82rem;color:var(--muted);">9.1m</td>
+                <td><span class="badge" style="background:var(--b-cinn-bg);color:var(--b-cinn-fg);">Significant Delay</span></td>
+                <td><button style="font-size:0.75rem;color:#C8463A;cursor:pointer;">Inspect →</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           09 · STATS & DATA
+      ══════════════════════════════════ -->
+      <section id="stats" class="mb-20 scroll-mt-6">
+        <p class="section-label">09 — Patterns</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Stats & Data</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Numbers elevated through typographic scale. The Cormorant display face makes data sing.</p>
+
+        <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px;">
+          <div class="card" style="padding:20px;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:6px;">Avg. Delay</p>
+            <div class="stat-num" style="color:#C8463A;">3.2<span style="font-size:1.5rem;color:var(--dim);">m</span></div>
+            <p style="font-size:0.72rem;color:#C8463A;margin-top:4px;">↑ 0.4m this week</p>
+          </div>
+          <div class="card" style="padding:20px;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:6px;">On-Time Rate</p>
+            <div class="stat-num" style="color:#3D9A6B;">87<span style="font-size:1.5rem;color:var(--dim);">%</span></div>
+            <p style="font-size:0.72rem;color:#3D9A6B;margin-top:4px;">↑ 2.1% vs last week</p>
+          </div>
+          <div class="card" style="padding:20px;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:6px;">Active Routes</p>
+            <div class="stat-num" style="color:#1D4E89;">142</div>
+            <p style="font-size:0.72rem;color:#3D9A6B;margin-top:4px;">+8 this month</p>
+          </div>
+          <div class="card" style="padding:20px;">
+            <p style="font-family:'Fira Code',monospace;font-size:0.65rem;color:var(--dim);margin-bottom:6px;">Incidents</p>
+            <div class="stat-num" style="color:#E8A020;">7</div>
+            <p style="font-size:0.72rem;color:#C8463A;margin-top:4px;">↑ 3 vs last week</p>
+          </div>
+        </div>
+
+        <!-- Performance breakdown -->
+        <div class="card" style="padding:24px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;">
+            <div>
+              <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);">Line Performance Breakdown</h4>
+              <p style="font-size:0.75rem;color:var(--dim);margin-top:2px;">On-time percentage by route, past 7 days</p>
+            </div>
+            <span class="badge" style="background:var(--bg-subtle);color:var(--secondary);">Jan 2024</span>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:14px;">
+            <div>
+              <div style="display:flex;justify-content:space-between;margin-bottom:5px;">
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;color:var(--secondary);">Line 7 — Westbound</span>
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;font-weight:500;color:var(--ink);">94%</span>
+              </div>
+              <div class="progress"><div class="progress-fill" style="width:94%;background:#3D9A6B;"></div></div>
+            </div>
+            <div>
+              <div style="display:flex;justify-content:space-between;margin-bottom:5px;">
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;color:var(--secondary);">Line 2 — Central</span>
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;font-weight:500;color:var(--ink);">87%</span>
+              </div>
+              <div class="progress"><div class="progress-fill" style="width:87%;background:#3D9A6B;"></div></div>
+            </div>
+            <div>
+              <div style="display:flex;justify-content:space-between;margin-bottom:5px;">
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;color:var(--secondary);">Line 14 — Airport</span>
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;font-weight:500;color:var(--ink);">71%</span>
+              </div>
+              <div class="progress"><div class="progress-fill" style="width:71%;background:#E8A020;"></div></div>
+            </div>
+            <div>
+              <div style="display:flex;justify-content:space-between;margin-bottom:5px;">
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;color:var(--secondary);">Line 9 — Northshore</span>
+                <span style="font-family:'Fira Code',monospace;font-size:0.72rem;font-weight:500;color:var(--ink);">58%</span>
+              </div>
+              <div class="progress"><div class="progress-fill" style="width:58%;background:#C8463A;"></div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           10 · CHARTS & GRAPHS
+      ══════════════════════════════════ -->
+      <section id="graphs" class="mb-20 scroll-mt-6">
+        <p class="section-label">10 — Patterns</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Charts & Graphs</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Data visualization built on raw SVG — no library, no overhead. Axes, curves, and colour all matched to the system.</p>
+
+        <!-- Multi-line chart -->
+        <div class="card" style="padding:24px;margin-bottom:16px;">
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:18px;">
+            <div>
+              <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:3px;">On-Time Performance</h4>
+              <p style="font-size:0.75rem;color:var(--dim);">Weekly percentage, past 8 weeks</p>
+            </div>
+            <div style="display:flex;gap:18px;">
+              <div style="display:flex;align-items:center;gap:7px;">
+                <div style="width:22px;height:2.5px;background:#C8463A;border-radius:2px;"></div>
+                <span style="font-family:'Fira Code',monospace;font-size:0.68rem;color:var(--muted);">Line 7</span>
+              </div>
+              <div style="display:flex;align-items:center;gap:7px;">
+                <div style="width:22px;height:2.5px;background:#1D4E89;border-radius:2px;"></div>
+                <span style="font-family:'Fira Code',monospace;font-size:0.68rem;color:var(--muted);">Line 9</span>
+              </div>
+            </div>
+          </div>
+          <svg id="chart-line" viewBox="0 0 580 230" preserveAspectRatio="xMidYMid meet" style="width:100%;height:auto;display:block;overflow:visible;"></svg>
+        </div>
+
+        <!-- Bar + Donut row -->
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px;">
+          <div class="card" style="padding:24px;">
+            <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:3px;">Avg. Delay by Route</h4>
+            <p style="font-size:0.75rem;color:var(--dim);margin-bottom:18px;">Minutes behind schedule, Jan 2024</p>
+            <svg id="chart-bar" viewBox="0 0 280 190" preserveAspectRatio="xMidYMid meet" style="width:100%;height:auto;display:block;overflow:visible;"></svg>
+          </div>
+          <div class="card" style="padding:24px;">
+            <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:3px;">Service Distribution</h4>
+            <p style="font-size:0.75rem;color:var(--dim);margin-bottom:18px;">By punctuality category, this week</p>
+            <svg id="chart-donut" viewBox="0 0 280 190" preserveAspectRatio="xMidYMid meet" style="width:100%;height:auto;display:block;overflow:visible;"></svg>
+          </div>
+        </div>
+
+        <!-- Area chart -->
+        <div class="card" style="padding:24px;">
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:18px;">
+            <div>
+              <h4 style="font-size:0.9rem;font-weight:500;color:var(--ink);margin-bottom:3px;">Daily Trips Completed</h4>
+              <p style="font-size:0.75rem;color:var(--dim);">All routes combined, past 7 days</p>
+            </div>
+            <span class="badge" style="background:#F9DDD9;color:#C8463A;">↑ 4.2% WoW</span>
+          </div>
+          <svg id="chart-area" viewBox="0 0 580 170" preserveAspectRatio="xMidYMid meet" style="width:100%;height:auto;display:block;overflow:visible;"></svg>
+        </div>
+      </section>
+
+
+      <!-- ══════════════════════════════════
+           11 · CODE
+      ══════════════════════════════════ -->
+      <section id="code" class="mb-20 scroll-mt-6">
+        <p class="section-label">11 — Usage</p>
+        <div class="section-rule"></div>
+        <h2 style="font-family:'Cormorant',serif;font-size:2.6rem;font-weight:400;margin-bottom:0.4rem;">Code Examples</h2>
+        <p style="color:var(--muted);font-size:0.875rem;margin-bottom:2.5rem;">Copy-paste ready snippets. Add the Tailwind config block to unlock all tokens.</p>
+
+        <pre><span class="tok-c">&lt;!-- tailwind.config (CDN) --&gt;</span>
+<span class="tok-k">&lt;script&gt;</span>
+  tailwind.config = {
+    theme: {
+      extend: {
+        fontFamily: {
+          display: [<span class="tok-s">'Cormorant'</span>, <span class="tok-s">'serif'</span>],
+          sans:    [<span class="tok-s">'Jost'</span>, <span class="tok-s">'sans-serif'</span>],
+        },
+        colors: {
+          cinnabar: { <span class="tok-n">500</span>: <span class="tok-s">'#C8463A'</span>, <span class="tok-n">600</span>: <span class="tok-s">'#A83530'</span> },
+          cream:    { <span class="tok-n">50</span>:  <span class="tok-s">'#FAFAF7'</span>, <span class="tok-n">100</span>: <span class="tok-s">'#F4F4EF'</span> },
+        },
+      }
+    }
+  }
+<span class="tok-k">&lt;/script&gt;</span>
+
+<span class="tok-c">&lt;!-- Primary button --&gt;</span>
+<span class="tok-k">&lt;button</span> <span class="tok-p">class</span>=<span class="tok-s">"bg-cinnabar-500 text-white text-sm font-medium
+         px-5 py-2.5 rounded-md hover:bg-cinnabar-600 transition-colors"</span><span class="tok-k">&gt;</span>
+  Get Started
+<span class="tok-k">&lt;/button&gt;</span>
+
+<span class="tok-c">&lt;!-- Display heading --&gt;</span>
+<span class="tok-k">&lt;h1</span> <span class="tok-p">class</span>=<span class="tok-s">"font-display text-6xl font-light text-cream-900 italic"</span><span class="tok-k">&gt;</span>
+  Built with <span class="tok-k">&lt;em</span> <span class="tok-p">class</span>=<span class="tok-s">"text-cinnabar-500"</span><span class="tok-k">&gt;</span>intention<span class="tok-k">&lt;/em&gt;</span>
+<span class="tok-k">&lt;/h1&gt;</span>
+
+<span class="tok-c">&lt;!-- Stat card --&gt;</span>
+<span class="tok-k">&lt;div</span> <span class="tok-p">class</span>=<span class="tok-s">"bg-white rounded-xl border border-cream-200 p-5 shadow-sm"</span><span class="tok-k">&gt;</span>
+  <span class="tok-k">&lt;p</span> <span class="tok-p">class</span>=<span class="tok-s">"font-mono text-xs text-cream-400 mb-1"</span><span class="tok-k">&gt;</span>On-Time Rate<span class="tok-k">&lt;/p&gt;</span>
+  <span class="tok-k">&lt;p</span> <span class="tok-p">class</span>=<span class="tok-s">"font-display text-5xl font-light"</span>
+     <span class="tok-p">style</span>=<span class="tok-s">"color: #3D9A6B"</span><span class="tok-k">&gt;</span><span class="tok-n">87</span>%<span class="tok-k">&lt;/p&gt;</span>
+<span class="tok-k">&lt;/div&gt;</span></pre>
+      </section>
+
+    </div><!-- /content -->
+  </main>
+
+</div>
+
+<script>
+  // Highlight active sidebar link on scroll
+  const sections = document.querySelectorAll('section[id]');
+  const links    = document.querySelectorAll('.nav-link');
+
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        links.forEach(l => {
+          l.classList.remove('active');
+          if (l.getAttribute('href') === '#' + e.target.id) l.classList.add('active');
+        });
+      }
+    });
+  }, { threshold: 0.25, rootMargin: '-15% 0px -65% 0px' });
+
+  sections.forEach(s => io.observe(s));
+
+  // ── Theme toggle ─────────────────────────────────────────────
+  function cssVar(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  function toggleTheme() {
+    const isDark = document.documentElement.classList.toggle('dark');
+    document.getElementById('theme-label').textContent = isDark ? 'DARK MODE' : 'LIGHT MODE';
+    document.getElementById('theme-icon').textContent  = isDark ? '🌙' : '☀️';
+    localStorage.setItem('lumina-theme', isDark ? 'dark' : 'light');
+    redrawCharts();
+  }
+
+  (function initTheme() {
+    const saved = localStorage.getItem('lumina-theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (saved === 'dark' || (!saved && prefersDark)) {
+      document.documentElement.classList.add('dark');
+      document.getElementById('theme-label').textContent = 'DARK MODE';
+      document.getElementById('theme-icon').textContent  = '🌙';
+    }
+  })();
+
+  // ── SVG chart helpers ────────────────────────────────────────
+  function $svg(tag, attrs) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    if (attrs) for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    return el;
+  }
+  function $t(content, attrs) {
+    const el = $svg('text', attrs);
+    el.textContent = content;
+    return el;
+  }
+  function f(n) { return +n.toFixed(2); }
+
+  // Catmull-Rom → cubic bezier
+  function spline(pts) {
+    if (pts.length < 2) return '';
+    let d = `M${f(pts[0][0])},${f(pts[0][1])}`;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[Math.max(0, i-1)], p1 = pts[i];
+      const p2 = pts[i+1], p3 = pts[Math.min(pts.length-1, i+2)];
+      const c1x = p1[0]+(p2[0]-p0[0])/6, c1y = p1[1]+(p2[1]-p0[1])/6;
+      const c2x = p2[0]-(p3[0]-p1[0])/6, c2y = p2[1]-(p3[1]-p1[1])/6;
+      d += ` C${f(c1x)},${f(c1y)} ${f(c2x)},${f(c2y)} ${f(p2[0])},${f(p2[1])}`;
+    }
+    return d;
+  }
+
+  // Animate rect growing upward from baseline
+  function growRect(el, toY, toH, delay) {
+    const dur = 650;
+    setTimeout(() => {
+      const t0 = performance.now();
+      (function tick(now) {
+        const t = Math.min(1, (now - t0) / dur);
+        const e = 1 - Math.pow(1 - t, 3);
+        el.setAttribute('y', f(toY + toH * (1 - e)));
+        el.setAttribute('height', f(toH * e));
+        if (t < 1) requestAnimationFrame(tick);
+      })(t0);
+    }, delay);
+  }
+
+  // ── Line chart ───────────────────────────────────────────────
+  function drawLineChart() {
+    const root = document.getElementById('chart-line');
+    if (!root) return;
+    const W=580, H=230, PL=50, PR=24, PT=18, PB=40;
+    const PW=W-PL-PR, PH=H-PT-PB, yMin=40, yMax=100;
+    const weeks=['W1','W2','W3','W4','W5','W6','W7','W8'];
+    const l7=[94,91,96,92,88,94,97,94], l9=[72,65,58,62,55,50,58,58];
+    const sx=i=>f(PL+(i/(weeks.length-1))*PW);
+    const sy=v=>f(PT+PH-((v-yMin)/(yMax-yMin))*PH);
+
+    // Grid + Y labels
+    [40,55,70,85,100].forEach(t => {
+      const y=sy(t);
+      root.appendChild($svg('line',{x1:PL,y1:y,x2:W-PR,y2:y,stroke:cssVar('--chart-grid'),'stroke-width':1}));
+      root.appendChild($t(t+'%',{x:PL-8,y:f(y+3.5),'font-family':'Fira Code,monospace','font-size':9,fill:cssVar('--dim'),'text-anchor':'end'}));
+    });
+    // X labels
+    weeks.forEach((w,i) => root.appendChild($t(w,{x:sx(i),y:H-8,'font-family':'Fira Code,monospace','font-size':9,fill:cssVar('--dim'),'text-anchor':'middle'})));
+    // Baseline
+    root.appendChild($svg('line',{x1:PL,y1:PT+PH,x2:W-PR,y2:PT+PH,stroke:cssVar('--border'),'stroke-width':1}));
+
+    function series(data, stroke, gid) {
+      const pts=data.map((v,i)=>[sx(i),sy(v)]);
+      const lp=spline(pts), bY=PT+PH;
+      const defs=$svg('defs'), g=$svg('linearGradient',{id:gid,x1:0,y1:0,x2:0,y2:1});
+      g.appendChild($svg('stop',{offset:'0%','stop-color':stroke,'stop-opacity':0.15}));
+      g.appendChild($svg('stop',{offset:'100%','stop-color':stroke,'stop-opacity':0.01}));
+      defs.appendChild(g); root.appendChild(defs);
+      root.appendChild($svg('path',{d:`${lp} L${sx(data.length-1)},${bY} L${sx(0)},${bY} Z`,fill:`url(#${gid})`}));
+      const line=$svg('path',{d:lp,fill:'none',stroke,'stroke-width':2,'stroke-linecap':'round','stroke-dasharray':800,'stroke-dashoffset':800});
+      root.appendChild(line);
+      line.style.transition='stroke-dashoffset 1.3s cubic-bezier(0.16,1,0.3,1) 0.1s';
+      requestAnimationFrame(()=>line.setAttribute('stroke-dashoffset',0));
+      pts.forEach(([x,y],i)=>{
+        const d=$svg('circle',{cx:x,cy:y,r:3.5,fill:cssVar('--surface'),stroke,'stroke-width':2,opacity:0});
+        root.appendChild(d);
+        d.style.transition=`opacity 0.2s ease ${0.5+i*0.07}s`;
+        requestAnimationFrame(()=>d.setAttribute('opacity',1));
+      });
+    }
+    series(l9,cssVar('--ox'),'gg-l9');
+    series(l7,cssVar('--cinn'),'gg-l7');
+  }
+
+  // ── Bar chart ────────────────────────────────────────────────
+  function drawBarChart() {
+    const root = document.getElementById('chart-bar');
+    if (!root) return;
+    const W=280, H=190, PL=42, PR=16, PT=16, PB=34;
+    const PW=W-PL-PR, PH=H-PT-PB, yMax=10;
+    const bars=[
+      {label:'Ln 7', value:1.2, colorVar:'--sage'},
+      {label:'Ln 2', value:2.8, colorVar:'--sage'},
+      {label:'Ln 14',value:5.4, colorVar:'--saff'},
+      {label:'Ln 9', value:9.1, colorVar:'--cinn'},
+    ];
+    const bw=PW/bars.length, bp=bw*0.25;
+    const sy=v=>f(PT+PH-(v/yMax)*PH);
+
+    [0,2.5,5,7.5,10].forEach(t=>{
+      const y=sy(t);
+      root.appendChild($svg('line',{x1:PL,y1:y,x2:W-PR,y2:y,stroke:cssVar('--chart-grid'),'stroke-width':1}));
+      root.appendChild($t(t+'m',{x:PL-6,y:f(y+3.5),'font-family':'Fira Code,monospace','font-size':8,fill:cssVar('--dim'),'text-anchor':'end'}));
+    });
+
+    bars.forEach((d,i)=>{
+      const color=cssVar(d.colorVar);
+      const x=f(PL+i*bw+bp), w=f(bw-bp*2);
+      const finalY=sy(d.value), finalH=f(PT+PH-finalY);
+      const rect=$svg('rect',{x,y:f(PT+PH),width:w,height:0,rx:3,fill:color});
+      root.appendChild(rect);
+      growRect(rect, finalY, finalH, i*80);
+      const vl=$t(d.value+'m',{x:f(x+w/2),y:f(finalY-5),'font-family':'Fira Code,monospace','font-size':9,fill:color,'text-anchor':'middle','font-weight':500,opacity:0});
+      root.appendChild(vl);
+      setTimeout(()=>{vl.style.transition='opacity 0.3s';vl.setAttribute('opacity',1);},420+i*80);
+      root.appendChild($t(d.label,{x:f(x+w/2),y:H-6,'font-family':'Fira Code,monospace','font-size':9,fill:cssVar('--muted'),'text-anchor':'middle'}));
+    });
+  }
+
+  // ── Donut chart ──────────────────────────────────────────────
+  function drawDonutChart() {
+    const root = document.getElementById('chart-donut');
+    if (!root) return;
+    const segs=[
+      {label:'On-time',  value:58, colorVar:'--sage'},
+      {label:'< 5 min',  value:26, colorVar:'--saff'},
+      {label:'> 5 min',  value:11, colorVar:'--cinn'},
+      {label:'Cancelled',value: 5, colorVar:'--stone'},
+    ];
+    const cx=90, cy=95, R=70, r=44, total=segs.reduce((s,d)=>s+d.value,0);
+    const xy=(a,rad)=>[f(cx+rad*Math.cos(a)),f(cy+rad*Math.sin(a))];
+    const arc=(a1,a2)=>{
+      const [ox1,oy1]=xy(a1,R),[ox2,oy2]=xy(a2,R);
+      const [ix1,iy1]=xy(a2,r),[ix2,iy2]=xy(a1,r);
+      const lg=a2-a1>Math.PI?1:0;
+      return `M${ox1},${oy1} A${R},${R} 0 ${lg},1 ${ox2},${oy2} L${ix1},${iy1} A${r},${r} 0 ${lg},0 ${ix2},${iy2} Z`;
+    };
+    let angle=-Math.PI/2;
+    segs.forEach((d,i)=>{
+      const color=cssVar(d.colorVar);
+      const sweep=(d.value/total)*2*Math.PI, end=angle+sweep;
+      const path=$svg('path',{d:arc(angle,end),fill:color,stroke:cssVar('--surface'),'stroke-width':2});
+      path.style.transformOrigin=`${cx}px ${cy}px`;
+      path.style.transform='scale(0)';
+      path.style.transition=`transform 0.45s cubic-bezier(0.34,1.4,0.64,1) ${i*0.08}s`;
+      root.appendChild(path);
+      requestAnimationFrame(()=>path.style.transform='scale(1)');
+      angle=end;
+    });
+    root.appendChild($t('58%',{x:cx,y:f(cy+2),'font-family':'Cormorant,serif','font-size':22,'font-weight':300,fill:cssVar('--ink'),'text-anchor':'middle','dominant-baseline':'middle'}));
+    root.appendChild($t('on-time',{x:cx,y:f(cy+18),'font-family':'Fira Code,monospace','font-size':8,fill:cssVar('--dim'),'text-anchor':'middle'}));
+    segs.forEach((d,i)=>{
+      const color=cssVar(d.colorVar);
+      const ly=24+i*40;
+      root.appendChild($svg('rect',{x:188,y:ly-7,width:10,height:10,rx:2,fill:color}));
+      root.appendChild($t(d.label,{x:204,y:f(ly+1.5),'font-family':'Jost,sans-serif','font-size':10.5,fill:cssVar('--secondary')}));
+      root.appendChild($t(d.value+'%',{x:276,y:f(ly+1.5),'font-family':'Fira Code,monospace','font-size':10.5,fill:cssVar('--ink'),'font-weight':500,'text-anchor':'end'}));
+    });
+  }
+
+  // ── Area chart ───────────────────────────────────────────────
+  function drawAreaChart() {
+    const root = document.getElementById('chart-area');
+    if (!root) return;
+    const W=580, H=170, PL=54, PR=24, PT=16, PB=36;
+    const PW=W-PL-PR, PH=H-PT-PB;
+    const days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+    const trips=[1842,1967,1934,2012,2156,1623,1241];
+    const yMin=1000, yMax=2300;
+    const sx=i=>f(PL+(i/(days.length-1))*PW);
+    const sy=v=>f(PT+PH-((v-yMin)/(yMax-yMin))*PH);
+
+    const acinn=cssVar('--cinn');
+    [1000,1500,2000].forEach(t=>{
+      const y=sy(t);
+      root.appendChild($svg('line',{x1:PL,y1:y,x2:W-PR,y2:y,stroke:cssVar('--chart-grid'),'stroke-width':1,'stroke-dasharray':'4 3'}));
+      root.appendChild($t((t/1000).toFixed(1)+'k',{x:PL-8,y:f(y+3.5),'font-family':'Fira Code,monospace','font-size':9,fill:cssVar('--dim'),'text-anchor':'end'}));
+    });
+    days.forEach((d,i)=>root.appendChild($t(d,{x:sx(i),y:H-6,'font-family':'Fira Code,monospace','font-size':9,fill:cssVar('--dim'),'text-anchor':'middle'})));
+
+    const pts=trips.map((v,i)=>[sx(i),sy(v)]), lp=spline(pts), bY=PT+PH;
+    const defs=$svg('defs'), g=$svg('linearGradient',{id:'af',x1:0,y1:0,x2:0,y2:1});
+    g.appendChild($svg('stop',{offset:'0%','stop-color':acinn,'stop-opacity':0.2}));
+    g.appendChild($svg('stop',{offset:'85%','stop-color':acinn,'stop-opacity':0}));
+    defs.appendChild(g); root.appendChild(defs);
+    root.appendChild($svg('path',{d:`${lp} L${sx(days.length-1)},${bY} L${sx(0)},${bY} Z`,fill:'url(#af)'}));
+    const line=$svg('path',{d:lp,fill:'none',stroke:acinn,'stroke-width':2.5,'stroke-linecap':'round','stroke-dasharray':800,'stroke-dashoffset':800});
+    root.appendChild(line);
+    line.style.transition='stroke-dashoffset 1.3s cubic-bezier(0.16,1,0.3,1) 0.15s';
+    requestAnimationFrame(()=>line.setAttribute('stroke-dashoffset',0));
+    pts.forEach(([x,y],i)=>{
+      const dot=$svg('circle',{cx:x,cy:y,r:4,fill:cssVar('--surface'),stroke:acinn,'stroke-width':2,opacity:0});
+      root.appendChild(dot);
+      dot.style.transition=`opacity 0.25s ease ${0.6+i*0.08}s`;
+      requestAnimationFrame(()=>dot.setAttribute('opacity',1));
+      const align=i===0?'start':i===days.length-1?'end':'middle';
+      const lbl=$t(trips[i].toLocaleString(),{x,y:f(y-10),'font-family':'Fira Code,monospace','font-size':8.5,fill:acinn,'text-anchor':align,'font-weight':500,opacity:0});
+      root.appendChild(lbl);
+      lbl.style.transition=`opacity 0.25s ease ${0.7+i*0.08}s`;
+      requestAnimationFrame(()=>lbl.setAttribute('opacity',1));
+    });
+  }
+
+  function clearSvg(id) {
+    const el = document.getElementById(id);
+    if (el) while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  function redrawCharts() {
+    clearSvg('chart-line');  drawLineChart();
+    clearSvg('chart-bar');   drawBarChart();
+    clearSvg('chart-donut'); drawDonutChart();
+    clearSvg('chart-area');  drawAreaChart();
+  }
+
+  // Trigger charts when section scrolls into view
+  (function() {
+    const sec = document.getElementById('graphs');
+    if (!sec) return;
+    let done = false;
+    const obs = new IntersectionObserver(entries => {
+      if (!done && entries[0].isIntersecting) {
+        done = true;
+        drawLineChart(); drawBarChart(); drawDonutChart(); drawAreaChart();
+        obs.disconnect();
+      }
+    }, { threshold: 0.1 });
+    obs.observe(sec);
+  })();
+</script>
+</body>
+</html>

--- a/frontend/logo.html
+++ b/frontend/logo.html
@@ -1,0 +1,717 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobilispect — Brand</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400;1,600&family=Fira+Code:wght@400;500&family=Jost:wght@300;400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink:    #1A1814;
+      --bg:     #0D0B09;
+      --surf:   #181410;
+      --surf2:  #201C18;
+      --cinn:   #C8463A;
+      --ox:     #1D4E89;
+      --cream:  #EDE8E0;
+      --muted:  #888480;
+      --dim:    #4E4844;
+      --stone:  #38302A;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--cream);
+      font-family: 'Jost', sans-serif;
+      font-weight: 300;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    /* Grain overlay */
+    body::before {
+      content: '';
+      position: fixed; inset: 0;
+      pointer-events: none;
+      z-index: 9999;
+      opacity: 0.04;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    }
+
+    /* ── Top signal bar ─── */
+    .signal-bar {
+      height: 3px;
+      background: linear-gradient(90deg, var(--cinn) 0%, var(--ox) 55%, var(--cinn) 100%);
+    }
+
+    /* ── Hero ─────────────────────────────────── */
+    .hero {
+      min-height: 80vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3.5rem;
+      padding: 5rem 2rem 4rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /* Grid overlay */
+    .hero::before {
+      content: '';
+      position: absolute; inset: 0;
+      background:
+        repeating-linear-gradient(0deg, transparent, transparent 47px, rgba(255,255,255,0.025) 47px, rgba(255,255,255,0.025) 48px),
+        repeating-linear-gradient(90deg, transparent, transparent 47px, rgba(255,255,255,0.025) 47px, rgba(255,255,255,0.025) 48px);
+      pointer-events: none;
+    }
+
+    /* Radial glow behind logo */
+    .hero::after {
+      content: '';
+      position: absolute;
+      top: 50%; left: 50%;
+      transform: translate(-50%, -55%);
+      width: 520px; height: 320px;
+      background: radial-gradient(ellipse, rgba(200,70,58,0.07) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .brand-label {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.62rem;
+      letter-spacing: 0.22em;
+      color: var(--cinn);
+      text-transform: uppercase;
+      opacity: 0;
+      animation: fadeUp 0.6s ease 0.2s forwards;
+      position: relative; z-index: 1;
+    }
+
+    /* ── Primary lockup ──────────────────────── */
+    .lockup {
+      display: flex;
+      align-items: center;
+      gap: 1.75rem;
+      opacity: 0;
+      animation: fadeUp 0.9s ease 0.5s forwards;
+      position: relative; z-index: 1;
+      cursor: default;
+    }
+
+    /* ── Mark SVG ─── */
+    .mark-wrap { flex-shrink: 0; }
+
+    /* Animated paths */
+    .r-left {
+      stroke-dasharray: 32; stroke-dashoffset: 32;
+      animation: draw 0.55s ease 0.9s forwards;
+    }
+    .r-right {
+      stroke-dasharray: 36; stroke-dashoffset: 36;
+      animation: draw 0.55s ease 1.35s forwards;
+    }
+    .pulse {
+      stroke-dasharray: 100; stroke-dashoffset: 100;
+      animation: draw 0.9s cubic-bezier(0.16,1,0.3,1) 0.95s forwards;
+    }
+    .scope {
+      stroke-dasharray: 96; stroke-dashoffset: 96;
+      transform-box: fill-box; transform-origin: center;
+      animation: draw 1.1s ease 1.6s forwards, spin 28s linear 2.8s infinite;
+    }
+    .peak-glow {
+      transform-box: fill-box; transform-origin: center;
+      transform: scale(0);
+      animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) 1.45s forwards, pulse 3s ease-in-out 2.5s infinite;
+    }
+    .peak-dot {
+      transform-box: fill-box; transform-origin: center;
+      transform: scale(0);
+      animation: popIn 0.45s cubic-bezier(0.34,1.7,0.64,1) 1.42s forwards;
+    }
+
+    /* Mark hover: subtle scale */
+    .lockup:hover .mark-bg { rx: 16; transition: 0.3s; }
+
+    /* ── Wordmark ─── */
+    .wm {
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+    .wm-name {
+      display: flex;
+      align-items: baseline;
+      line-height: 1;
+    }
+    .wm-m {
+      font-family: 'Cormorant Garamond', Georgia, serif;
+      font-style: italic;
+      font-weight: 300;
+      font-size: 3.4rem;
+      color: var(--cream);
+      letter-spacing: -0.015em;
+    }
+    .wm-s {
+      font-family: 'Fira Code', monospace;
+      font-weight: 500;
+      font-size: 2.05rem;
+      color: var(--cinn);
+      letter-spacing: -0.03em;
+      margin-bottom: 2px;
+    }
+    .wm-tag {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.16em;
+      color: var(--muted);
+      text-transform: uppercase;
+      padding-left: 2px;
+    }
+
+    /* ── Section layout ────────────────────── */
+    .section {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 2rem 5rem;
+    }
+
+    .section-label {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.2em;
+      color: var(--dim);
+      text-transform: uppercase;
+      margin-bottom: 1.75rem;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--stone);
+    }
+
+    /* ── Variants grid ─────────────────────── */
+    .variants {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      border-radius: 12px;
+      overflow: hidden;
+      border: 1px solid var(--stone);
+      opacity: 0;
+      animation: fadeUp 0.8s ease 1.6s forwards;
+    }
+    @media (max-width: 640px) {
+      .variants { grid-template-columns: 1fr; }
+    }
+
+    .var-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.75rem;
+      padding: 2.75rem 1.5rem;
+      border-right: 1px solid var(--stone);
+    }
+    .var-card:last-child { border-right: none; }
+
+    .var-dark  { background: #100E0C; }
+    .var-light { background: #FAFAF7; }
+    .var-mono  { background: var(--surf2); }
+
+    .var-name {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.58rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+    .var-dark .var-name  { color: var(--dim); }
+    .var-light .var-name { color: #A8A49B; }
+    .var-mono .var-name  { color: var(--muted); }
+
+    /* Small wordmark in variants */
+    .wm-sm { display: flex; align-items: center; gap: 0.6rem; }
+    .wm-sm-name { display: flex; align-items: baseline; }
+    .wm-sm .wm-m { font-size: 1.5rem; }
+    .wm-sm .wm-s { font-size: 0.95rem; margin-bottom: 1px; }
+    .wm-sm-light .wm-m { color: var(--ink); }
+
+    /* ── Scale section ─────────────────────── */
+    .sizes {
+      display: flex;
+      align-items: flex-end;
+      gap: 2.75rem;
+      flex-wrap: wrap;
+      opacity: 0;
+      animation: fadeUp 0.8s ease 1.85s forwards;
+    }
+    .size-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .size-px {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.55rem;
+      letter-spacing: 0.1em;
+      color: var(--dim);
+    }
+
+    /* ── Palette ────────────────────────────── */
+    .palette {
+      display: flex;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 1px solid var(--stone);
+      opacity: 0;
+      animation: fadeUp 0.8s ease 2.05s forwards;
+    }
+    .chip {
+      flex: 1;
+      height: 72px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      padding: 8px 10px;
+      min-width: 0;
+    }
+    .chip-name {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.52rem;
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .chip-hex {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.5rem;
+      letter-spacing: 0.03em;
+      opacity: 0.65;
+      margin-top: 1px;
+    }
+
+    /* ── Type specimen ─────────────────────── */
+    .type-row {
+      display: flex;
+      gap: 1px;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 1px solid var(--stone);
+      opacity: 0;
+      animation: fadeUp 0.8s ease 2.2s forwards;
+    }
+    .type-cell {
+      flex: 1;
+      background: var(--surf);
+      padding: 2rem 1.75rem;
+    }
+    .type-cell + .type-cell { border-left: 1px solid var(--stone); }
+    .type-meta {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.58rem;
+      letter-spacing: 0.14em;
+      color: var(--dim);
+      text-transform: uppercase;
+      margin-bottom: 1rem;
+    }
+    .type-display {
+      font-family: 'Cormorant Garamond', serif;
+      font-style: italic;
+      font-weight: 300;
+      font-size: 2.8rem;
+      color: var(--cream);
+      line-height: 1.1;
+    }
+    .type-mono {
+      font-family: 'Fira Code', monospace;
+      font-weight: 500;
+      font-size: 1.8rem;
+      color: var(--cinn);
+      line-height: 1.1;
+    }
+    .type-body {
+      font-family: 'Jost', sans-serif;
+      font-weight: 300;
+      font-size: 0.9rem;
+      color: var(--cream);
+      line-height: 1.7;
+      margin-top: 0.75rem;
+      color: var(--muted);
+    }
+
+    /* ── Construction view ─────────────────── */
+    .construction {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3.5rem;
+      background: var(--surf);
+      border: 1px solid var(--stone);
+      border-radius: 12px;
+      opacity: 0;
+      animation: fadeUp 0.8s ease 2.35s forwards;
+    }
+
+    /* ── Footer ─────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--stone);
+      padding: 2rem;
+      text-align: center;
+    }
+    footer p {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.14em;
+      color: var(--dim);
+      text-transform: uppercase;
+    }
+
+    /* ── Keyframes ───────────────────────────── */
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(18px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes draw {
+      to { stroke-dashoffset: 0; }
+    }
+    @keyframes popIn {
+      to { transform: scale(1); }
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.5; transform: scale(1); }
+      50%       { opacity: 0.15; transform: scale(1.5); }
+    }
+  </style>
+</head>
+<body>
+
+<div class="signal-bar"></div>
+
+<!-- ═══ HERO ═══════════════════════════════════════════ -->
+<section class="hero">
+
+  <div class="brand-label">Brand Identity · 2026</div>
+
+  <div class="lockup">
+
+    <!-- ── Mark (animated) ── -->
+    <div class="mark-wrap">
+      <svg width="88" height="88" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Mobilispect mark">
+        <defs>
+          <radialGradient id="glow-h" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#C8463A" stop-opacity="0.55"/>
+            <stop offset="100%" stop-color="#C8463A" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+
+        <!-- Container -->
+        <rect class="mark-bg" x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+
+        <!-- Faint measurement grid -->
+        <line x1="6" y1="20" x2="50" y2="20" stroke="#FFFFFF" stroke-opacity="0.04" stroke-width="0.5"/>
+        <line x1="6" y1="36" x2="50" y2="36" stroke="#FFFFFF" stroke-opacity="0.04" stroke-width="0.5"/>
+
+        <!-- Baseline left -->
+        <line x1="5" y1="28" x2="15" y2="28"
+          stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"
+          class="r-left"/>
+
+        <!-- Baseline right -->
+        <line x1="33" y1="28" x2="51" y2="28"
+          stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"
+          class="r-right"/>
+
+        <!-- Pulse deviation path: dip then spike -->
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28"
+          stroke="#C8463A" stroke-width="2.25" fill="none"
+          stroke-linecap="round" stroke-linejoin="round"
+          class="pulse"/>
+
+        <!-- Scope ring (slowly spinning) -->
+        <circle cx="28" cy="28" r="15"
+          stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.38"
+          stroke-dasharray="3.8 2.8"
+          class="scope"/>
+
+        <!-- Peak glow halo -->
+        <circle cx="28" cy="14" r="9" fill="url(#glow-h)" class="peak-glow"/>
+
+        <!-- Peak inspection dot -->
+        <circle cx="28" cy="14" r="3" fill="#C8463A" class="peak-dot"/>
+        <circle cx="28" cy="14" r="1.25" fill="#F28070" class="peak-dot"/>
+      </svg>
+    </div>
+
+    <!-- ── Wordmark ── -->
+    <div class="wm">
+      <div class="wm-name">
+        <span class="wm-m">mobili</span><span class="wm-s">spect</span>
+      </div>
+      <div class="wm-tag">Transit performance · accountability</div>
+    </div>
+
+  </div><!-- /lockup -->
+
+</section><!-- /hero -->
+
+
+<!-- ═══ VARIANTS ══════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Variants</div>
+  <div class="variants">
+
+    <!-- Dark -->
+    <div class="var-card var-dark">
+      <div class="wm-sm">
+        <svg width="44" height="44" viewBox="0 0 56 56" fill="none">
+          <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+          <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+          <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+          <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28"
+            stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+          <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.38" stroke-dasharray="3.8 2.8"/>
+          <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+          <circle cx="28" cy="14" r="1.25" fill="#F28070"/>
+        </svg>
+        <div class="wm-sm-name">
+          <span class="wm-m">mobili</span><span class="wm-s">spect</span>
+        </div>
+      </div>
+      <div class="var-name">Dark · Primary</div>
+    </div>
+
+    <!-- Light -->
+    <div class="var-card var-light">
+      <div class="wm-sm wm-sm-light">
+        <svg width="44" height="44" viewBox="0 0 56 56" fill="none">
+          <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#F0EDE6" stroke="#DDD9D2" stroke-width="0.5"/>
+          <line x1="5" y1="28" x2="15" y2="28" stroke="#C8C4BC" stroke-width="1.75" stroke-linecap="round"/>
+          <line x1="33" y1="28" x2="51" y2="28" stroke="#C8C4BC" stroke-width="1.75" stroke-linecap="round"/>
+          <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28"
+            stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+          <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.35" stroke-dasharray="3.8 2.8"/>
+          <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+          <circle cx="28" cy="14" r="1.25" fill="#E87060"/>
+        </svg>
+        <div class="wm-sm-name">
+          <span class="wm-m" style="color:#1A1814">mobili</span><span class="wm-s">spect</span>
+        </div>
+      </div>
+      <div class="var-name" style="color:#A8A49B">Light · Reversed</div>
+    </div>
+
+    <!-- Mark only -->
+    <div class="var-card var-mono">
+      <svg width="72" height="72" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28"
+          stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.38" stroke-dasharray="3.8 2.8"/>
+        <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+        <circle cx="28" cy="14" r="1.25" fill="#F28070"/>
+      </svg>
+      <div class="var-name">Mark · Standalone</div>
+    </div>
+
+  </div>
+</div>
+
+
+<!-- ═══ SCALE ════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Scale</div>
+  <div class="sizes">
+
+    <div class="size-item">
+      <svg width="80" height="80" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.38" stroke-dasharray="3.8 2.8"/>
+        <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+        <circle cx="28" cy="14" r="1.25" fill="#F28070"/>
+      </svg>
+      <div class="size-px">80 px</div>
+    </div>
+
+    <div class="size-item">
+      <svg width="56" height="56" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.38" stroke-dasharray="3.8 2.8"/>
+        <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+        <circle cx="28" cy="14" r="1.25" fill="#F28070"/>
+      </svg>
+      <div class="size-px">56 px</div>
+    </div>
+
+    <div class="size-item">
+      <svg width="40" height="40" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="1.75" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="2.25" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.75" stroke-opacity="0.4" stroke-dasharray="3.8 2.8"/>
+        <circle cx="28" cy="14" r="3" fill="#C8463A"/>
+        <circle cx="28" cy="14" r="1.5" fill="#F28070"/>
+      </svg>
+      <div class="size-px">40 px</div>
+    </div>
+
+    <div class="size-item">
+      <svg width="28" height="28" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#4A403A" stroke-width="2" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#4A403A" stroke-width="2" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="14" r="4" fill="#C8463A"/>
+      </svg>
+      <div class="size-px">28 px</div>
+    </div>
+
+    <div class="size-item">
+      <svg width="20" height="20" viewBox="0 0 56 56" fill="none">
+        <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814"/>
+        <line x1="5" y1="28" x2="15" y2="28" stroke="#4A403A" stroke-width="2.5" stroke-linecap="round"/>
+        <line x1="33" y1="28" x2="51" y2="28" stroke="#4A403A" stroke-width="2.5" stroke-linecap="round"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="3" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="14" r="5" fill="#C8463A"/>
+      </svg>
+      <div class="size-px">20 px</div>
+    </div>
+
+    <div class="size-item">
+      <svg width="14" height="14" viewBox="0 0 56 56" fill="none">
+        <rect x="1" y="1" width="54" height="54" rx="12" fill="#1A1814"/>
+        <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+        <circle cx="28" cy="14" r="6" fill="#C8463A"/>
+      </svg>
+      <div class="size-px">14 px</div>
+    </div>
+
+  </div>
+</div>
+
+
+<!-- ═══ PALETTE ══════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Palette</div>
+  <div class="palette">
+    <div class="chip" style="background:#1A1814;">
+      <div class="chip-name" style="color:#888480;">Ink</div>
+      <div class="chip-hex" style="color:#888480;">#1A1814</div>
+    </div>
+    <div class="chip" style="background:#C8463A;">
+      <div class="chip-name" style="color:rgba(255,255,255,0.9);">Cinnabar</div>
+      <div class="chip-hex" style="color:rgba(255,255,255,0.65);">#C8463A</div>
+    </div>
+    <div class="chip" style="background:#1D4E89;">
+      <div class="chip-name" style="color:rgba(255,255,255,0.9);">Oxford</div>
+      <div class="chip-hex" style="color:rgba(255,255,255,0.65);">#1D4E89</div>
+    </div>
+    <div class="chip" style="background:#E8A020;">
+      <div class="chip-name" style="color:rgba(26,24,20,0.85);">Saffron</div>
+      <div class="chip-hex" style="color:rgba(26,24,20,0.6);">#E8A020</div>
+    </div>
+    <div class="chip" style="background:#3D9A6B;">
+      <div class="chip-name" style="color:rgba(255,255,255,0.9);">Sage</div>
+      <div class="chip-hex" style="color:rgba(255,255,255,0.65);">#3D9A6B</div>
+    </div>
+    <div class="chip" style="background:#FAFAF7; border-left:1px solid #E0DDD6;">
+      <div class="chip-name" style="color:#888480;">Cream</div>
+      <div class="chip-hex" style="color:#888480;">#FAFAF7</div>
+    </div>
+  </div>
+</div>
+
+
+<!-- ═══ TYPOGRAPHY ════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Typography</div>
+  <div class="type-row">
+
+    <div class="type-cell">
+      <div class="type-meta">Cormorant Garamond · Italic 300 · Display</div>
+      <div class="type-display">mobili</div>
+      <div class="type-body">Used for the "mobili" wordmark portion and page-level display headings. The italic cut conveys motion and flow — transit in action.</div>
+    </div>
+
+    <div class="type-cell">
+      <div class="type-meta">Fira Code · Medium 500 · Technical</div>
+      <div class="type-mono">spect</div>
+      <div class="type-body">Used for the "spect" wordmark, data labels, monospaced values, and system identifiers. Precision. Accountability. Measurement.</div>
+    </div>
+
+    <div class="type-cell">
+      <div class="type-meta">Jost · Light 300 · Body</div>
+      <div class="type-display" style="font-family:'Jost',sans-serif;font-style:normal;font-size:1.75rem;font-weight:300;letter-spacing:-0.01em;">Route&nbsp;data</div>
+      <div class="type-body">Primary body typeface. Geometric, neutral, highly legible. Carries the informational density of transit dashboards without fatigue.</div>
+    </div>
+
+  </div>
+</div>
+
+
+<!-- ═══ CONSTRUCTION ══════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Mark Construction</div>
+  <div class="construction">
+    <svg width="280" height="280" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <!-- Construction annotations -->
+
+      <!-- Center crosshair -->
+      <line x1="28" y1="4" x2="28" y2="52" stroke="#C8463A" stroke-width="0.3" stroke-opacity="0.2" stroke-dasharray="2 2"/>
+      <line x1="4" y1="28" x2="52" y2="28" stroke="#C8463A" stroke-width="0.3" stroke-opacity="0.2" stroke-dasharray="2 2"/>
+
+      <!-- Outer container -->
+      <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="none" stroke="#4E4844" stroke-width="0.5" stroke-dasharray="2 2"/>
+
+      <!-- Scope ring construction -->
+      <circle cx="28" cy="28" r="15" fill="none" stroke="#C8463A" stroke-width="0.4" stroke-opacity="0.25" stroke-dasharray="1.5 1.5"/>
+
+      <!-- Grid lines -->
+      <line x1="6" y1="14" x2="50" y2="14" stroke="#4E4844" stroke-width="0.3" stroke-opacity="0.5"/>
+      <line x1="6" y1="20" x2="50" y2="20" stroke="#4E4844" stroke-width="0.3" stroke-opacity="0.5"/>
+      <line x1="6" y1="28" x2="50" y2="28" stroke="#4E4844" stroke-width="0.3" stroke-opacity="0.5"/>
+      <line x1="6" y1="36" x2="50" y2="36" stroke="#4E4844" stroke-width="0.3" stroke-opacity="0.5"/>
+      <line x1="6" y1="42" x2="50" y2="42" stroke="#4E4844" stroke-width="0.3" stroke-opacity="0.5"/>
+
+      <!-- Key anchor point markers -->
+      <circle cx="15" cy="28" r="1" fill="none" stroke="#888480" stroke-width="0.5"/>
+      <circle cx="33" cy="28" r="1" fill="none" stroke="#888480" stroke-width="0.5"/>
+      <circle cx="22" cy="38" r="1" fill="none" stroke="#888480" stroke-width="0.5"/>
+      <circle cx="28" cy="14" r="1" fill="none" stroke="#C8463A" stroke-width="0.5"/>
+
+      <!-- Actual mark elements -->
+      <line x1="5" y1="28" x2="15" y2="28" stroke="#888480" stroke-width="1.5" stroke-linecap="round"/>
+      <line x1="33" y1="28" x2="51" y2="28" stroke="#888480" stroke-width="1.5" stroke-linecap="round"/>
+      <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28"
+        stroke="#C8463A" stroke-width="2" fill="none" stroke-linecap="round"/>
+      <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.6" stroke-opacity="0.4" stroke-dasharray="3.5 2.5"/>
+      <circle cx="28" cy="14" r="2.5" fill="#C8463A"/>
+
+      <!-- Dimension labels -->
+      <text x="28" y="60" font-family="Fira Code,monospace" font-size="2.8" fill="#4E4844" text-anchor="middle">56 × 56 · rx 13</text>
+    </svg>
+  </div>
+</div>
+
+
+<footer>
+  <p>Mobilispect · Brand System · 2026 · Transit performance accountability</p>
+</footer>
+
+</body>
+</html>

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -243,16 +243,6 @@ pub struct RouteSummary {
 }
 
 impl RouteSummary {
-    /// "green", "yellow", "red", or "none"
-    pub fn status_class(&self) -> &'static str {
-        match self.avg_on_time_pct {
-            Some(pct) if pct >= 80.0 => "green",
-            Some(pct) if pct >= 60.0 => "yellow",
-            Some(_) => "red",
-            None => "none",
-        }
-    }
-
     pub fn status_label(&self) -> &'static str {
         match self.avg_on_time_pct {
             Some(pct) if pct >= 80.0 => "On track",
@@ -549,16 +539,6 @@ impl ScorecardRoute {
             Some(p) if p >= *floor_pct => "Competitive",
             Some(_) => "Below all",
             None => "No data",
-        }
-    }
-
-    /// CSS badge class: "green" / "yellow" / "red" / "none".
-    pub fn status_class(&self, floor_pct: &f64, ceiling_pct: &f64) -> &'static str {
-        match self.avg_on_time_pct {
-            Some(p) if p >= *ceiling_pct => "green",
-            Some(p) if p >= *floor_pct => "yellow",
-            Some(_) => "red",
-            None => "none",
         }
     }
 
@@ -969,30 +949,6 @@ mod tests {
     fn on_time_gap_class_is_empty_without_data() {
         let r = make_scorecard_route(None, None);
         assert_eq!(r.on_time_gap_class(&89.0), "");
-    }
-
-    #[test]
-    fn status_class_is_green_at_or_above_ceiling() {
-        let r = make_scorecard_route(Some(96.0), None);
-        assert_eq!(r.status_class(&89.0, &96.0), "green");
-    }
-
-    #[test]
-    fn status_class_is_yellow_between_floor_and_ceiling() {
-        let r = make_scorecard_route(Some(91.0), None);
-        assert_eq!(r.status_class(&89.0, &96.0), "yellow");
-    }
-
-    #[test]
-    fn status_class_is_red_under_floor() {
-        let r = make_scorecard_route(Some(71.0), None);
-        assert_eq!(r.status_class(&89.0, &96.0), "red");
-    }
-
-    #[test]
-    fn status_class_is_none_without_data() {
-        let r = make_scorecard_route(None, None);
-        assert_eq!(r.status_class(&89.0, &96.0), "none");
     }
 
     // ── RouteSummary::badge_variant tests ──────────────────────────────────────

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -262,6 +262,15 @@ impl RouteSummary {
         }
     }
 
+    pub fn badge_variant(&self) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(pct) if pct >= 80.0 => "good",
+            Some(pct) if pct >= 60.0 => "mixed",
+            Some(_) => "bad",
+            None => "neutral",
+        }
+    }
+
     pub fn on_time_display(&self) -> String {
         match self.avg_on_time_pct {
             Some(pct) => format!("{pct}%"),
@@ -550,6 +559,15 @@ impl ScorecardRoute {
             Some(p) if p >= *floor_pct => "yellow",
             Some(_) => "red",
             None => "none",
+        }
+    }
+
+    pub fn badge_variant(&self, floor_pct: &f64, ceiling_pct: &f64) -> &'static str {
+        match self.avg_on_time_pct {
+            Some(p) if p >= *ceiling_pct => "good",
+            Some(p) if p >= *floor_pct => "mixed",
+            Some(_) => "bad",
+            None => "neutral",
         }
     }
 
@@ -975,6 +993,71 @@ mod tests {
     fn status_class_is_none_without_data() {
         let r = make_scorecard_route(None, None);
         assert_eq!(r.status_class(&89.0, &96.0), "none");
+    }
+
+    // ── RouteSummary::badge_variant tests ──────────────────────────────────────
+
+    fn make_route_summary(on_time: Option<f64>) -> RouteSummary {
+        RouteSummary {
+            agency_id: "stm".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_on_time_pct: on_time,
+            avg_delay_secs: None,
+            trips_run: None,
+            trips_total: None,
+            days_measured: None,
+        }
+    }
+
+    #[test]
+    fn route_summary_badge_variant_good_at_or_above_80() {
+        assert_eq!(make_route_summary(Some(80.0)).badge_variant(), "good");
+        assert_eq!(make_route_summary(Some(95.0)).badge_variant(), "good");
+    }
+
+    #[test]
+    fn route_summary_badge_variant_mixed_between_60_and_80() {
+        assert_eq!(make_route_summary(Some(60.0)).badge_variant(), "mixed");
+        assert_eq!(make_route_summary(Some(79.9)).badge_variant(), "mixed");
+    }
+
+    #[test]
+    fn route_summary_badge_variant_bad_below_60() {
+        assert_eq!(make_route_summary(Some(59.9)).badge_variant(), "bad");
+        assert_eq!(make_route_summary(Some(0.0)).badge_variant(), "bad");
+    }
+
+    #[test]
+    fn route_summary_badge_variant_neutral_when_no_data() {
+        assert_eq!(make_route_summary(None).badge_variant(), "neutral");
+    }
+
+    // ── ScorecardRoute::badge_variant tests ──────────────────────────────────────
+
+    #[test]
+    fn scorecard_badge_variant_good_at_or_above_ceiling() {
+        let r = make_scorecard_route(Some(96.0), None);
+        assert_eq!(r.badge_variant(&89.0, &96.0), "good");
+    }
+
+    #[test]
+    fn scorecard_badge_variant_mixed_between_floor_and_ceiling() {
+        let r = make_scorecard_route(Some(91.0), None);
+        assert_eq!(r.badge_variant(&89.0, &96.0), "mixed");
+    }
+
+    #[test]
+    fn scorecard_badge_variant_bad_under_floor() {
+        let r = make_scorecard_route(Some(71.0), None);
+        assert_eq!(r.badge_variant(&89.0, &96.0), "bad");
+    }
+
+    #[test]
+    fn scorecard_badge_variant_neutral_when_no_data() {
+        let r = make_scorecard_route(None, None);
+        assert_eq!(r.badge_variant(&89.0, &96.0), "neutral");
     }
 
     #[test]

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -32,6 +32,23 @@ impl RouteSpeedChart {
     }
 }
 
+impl RouteSpeedCard {
+    pub fn avg_scheduled_speed_kmh_display(&self) -> String {
+        fmt_speed_kmh(self.avg_scheduled_speed_mps)
+    }
+
+    pub fn avg_actual_speed_kmh_display(&self) -> String {
+        fmt_speed_kmh(self.avg_actual_speed_mps)
+    }
+}
+
+fn fmt_speed_kmh(mps: Option<f64>) -> String {
+    match mps {
+        None => "—".to_string(),
+        Some(s) => format!("{:.1}", s * 3.6),
+    }
+}
+
 pub struct RouteSpeedCard {
     pub idx: usize,
     pub agency_name: String,
@@ -586,5 +603,75 @@ mod tests {
     #[test]
     fn spacing_unit_kilometres() {
         assert_eq!(chart_with_spacing(Some(1200.0)).avg_stop_spacing_unit(), "km");
+    }
+
+    #[test]
+    fn scheduled_speed_display_formats_kmh_one_decimal() {
+        // 10.0 m/s = 36.0 km/h
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
+            avg_scheduled_speed_mps: Some(10.0),
+            avg_actual_speed_mps: None,
+            classification: None,
+        };
+        assert_eq!(card.avg_scheduled_speed_kmh_display(), "36.0");
+    }
+
+    #[test]
+    fn scheduled_speed_display_dash_when_none() {
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: None,
+            classification: None,
+        };
+        assert_eq!(card.avg_scheduled_speed_kmh_display(), "—");
+    }
+
+    #[test]
+    fn actual_speed_display_formats_kmh_one_decimal() {
+        // 5.0 m/s = 18.0 km/h
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: Some(5.0),
+            classification: None,
+        };
+        assert_eq!(card.avg_actual_speed_kmh_display(), "18.0");
+    }
+
+    #[test]
+    fn actual_speed_display_dash_when_none() {
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: None,
+            classification: None,
+        };
+        assert_eq!(card.avg_actual_speed_kmh_display(), "—");
     }
 }

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -101,6 +101,14 @@ impl RouteClass {
             RouteClass::Express => "express",
         }
     }
+
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            RouteClass::Local => "Local · 12-18 km/h",
+            RouteClass::Rapid => "Rapid · 18-25 km/h",
+            RouteClass::Express => "Express · >25 km/h",
+        }
+    }
 }
 
 pub fn classify_by_spacing(avg_m: f64) -> RouteClass {
@@ -395,6 +403,13 @@ mod tests {
         assert_eq!(RouteClass::Local.css_class(), "local");
         assert_eq!(RouteClass::Rapid.css_class(), "rapid");
         assert_eq!(RouteClass::Express.css_class(), "express");
+    }
+
+    #[test]
+    fn route_class_display_label() {
+        assert_eq!(RouteClass::Local.display_label(), "Local · 12-18 km/h");
+        assert_eq!(RouteClass::Rapid.display_label(), "Rapid · 18-25 km/h");
+        assert_eq!(RouteClass::Express.display_label(), "Express · >25 km/h");
     }
 
     #[test]

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -16,6 +16,29 @@ impl DirectionSpeedChart {
             Some(m) => format!("{:.0} m", m),
         }
     }
+
+    pub fn avg_stop_spacing_class(&self) -> &'static str {
+        match self.avg_stop_spacing_m {
+            None => "none",
+            Some(m) => classify_by_spacing(m).css_class(),
+        }
+    }
+
+    pub fn avg_stop_spacing_number(&self) -> String {
+        match self.avg_stop_spacing_m {
+            None => "—".to_string(),
+            Some(m) if m >= 1000.0 => format!("{:.1}", m / 1000.0),
+            Some(m) => format!("{:.0}", m),
+        }
+    }
+
+    pub fn avg_stop_spacing_unit(&self) -> &'static str {
+        match self.avg_stop_spacing_m {
+            None => "",
+            Some(m) if m >= 1000.0 => "km",
+            Some(_) => "m",
+        }
+    }
 }
 
 pub struct RouteSpeedCard {
@@ -533,5 +556,64 @@ mod tests {
         row1.avg_stop_spacing_m = Some(600.0);
         let cards = build_speed_cards(vec![row0, row1], &HashMap::new());
         assert_eq!(cards[0].classification, Some(RouteClass::Rapid));
+    }
+
+    fn chart_with_spacing(m: Option<f64>) -> DirectionSpeedChart {
+        DirectionSpeedChart {
+            chart_id: "x".into(),
+            title: "T".into(),
+            chart_json: "[]".into(),
+            avg_stop_spacing_m: m,
+        }
+    }
+
+    #[test]
+    fn spacing_class_none_when_no_data() {
+        assert_eq!(chart_with_spacing(None).avg_stop_spacing_class(), "none");
+    }
+
+    #[test]
+    fn spacing_class_local_below_500m() {
+        assert_eq!(chart_with_spacing(Some(300.0)).avg_stop_spacing_class(), "local");
+    }
+
+    #[test]
+    fn spacing_class_rapid_500_to_1500m() {
+        assert_eq!(chart_with_spacing(Some(800.0)).avg_stop_spacing_class(), "rapid");
+    }
+
+    #[test]
+    fn spacing_class_express_1500m_and_above() {
+        assert_eq!(chart_with_spacing(Some(2000.0)).avg_stop_spacing_class(), "express");
+    }
+
+    #[test]
+    fn spacing_number_none() {
+        assert_eq!(chart_with_spacing(None).avg_stop_spacing_number(), "—");
+    }
+
+    #[test]
+    fn spacing_number_metres() {
+        assert_eq!(chart_with_spacing(Some(342.0)).avg_stop_spacing_number(), "342");
+    }
+
+    #[test]
+    fn spacing_number_kilometres() {
+        assert_eq!(chart_with_spacing(Some(1200.0)).avg_stop_spacing_number(), "1.2");
+    }
+
+    #[test]
+    fn spacing_unit_none() {
+        assert_eq!(chart_with_spacing(None).avg_stop_spacing_unit(), "");
+    }
+
+    #[test]
+    fn spacing_unit_metres() {
+        assert_eq!(chart_with_spacing(Some(342.0)).avg_stop_spacing_unit(), "m");
+    }
+
+    #[test]
+    fn spacing_unit_kilometres() {
+        assert_eq!(chart_with_spacing(Some(1200.0)).avg_stop_spacing_unit(), "km");
     }
 }

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -23,13 +23,6 @@ impl RouteSpeedCard {
         fmt_speed_kmh(self.avg_actual_speed_mps)
     }
 
-    pub fn avg_stop_spacing_class(&self) -> &'static str {
-        match self.avg_stop_spacing_m {
-            None => "none",
-            Some(m) => classify_by_spacing(m).css_class(),
-        }
-    }
-
     pub fn avg_stop_spacing_number(&self) -> String {
         match self.avg_stop_spacing_m {
             None => "—".to_string(),
@@ -452,26 +445,6 @@ mod tests {
             avg_stop_spacing_m: m,
             classification: None,
         }
-    }
-
-    #[test]
-    fn spacing_class_none_when_no_data() {
-        assert_eq!(card_with_spacing(None).avg_stop_spacing_class(), "none");
-    }
-
-    #[test]
-    fn spacing_class_local_below_500m() {
-        assert_eq!(card_with_spacing(Some(300.0)).avg_stop_spacing_class(), "local");
-    }
-
-    #[test]
-    fn spacing_class_rapid_500_to_1500m() {
-        assert_eq!(card_with_spacing(Some(800.0)).avg_stop_spacing_class(), "rapid");
-    }
-
-    #[test]
-    fn spacing_class_express_1500m_and_above() {
-        assert_eq!(card_with_spacing(Some(2000.0)).avg_stop_spacing_class(), "express");
     }
 
     #[test]

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -1,13 +1,28 @@
 use crate::speed::RouteSpeedDayType;
 use std::collections::HashMap;
 
-pub struct RouteSpeedChart {
-    pub chart_id: String,
-    pub chart_json: String,
+pub struct RouteSpeedCard {
+    pub idx: usize,
+    pub agency_name: String,
+    pub agency_id: String,
+    pub route_id: String,
+    pub short_name: String,
+    pub long_name: String,
+    pub avg_scheduled_speed_mps: Option<f64>,
+    pub avg_actual_speed_mps: Option<f64>,
     pub avg_stop_spacing_m: Option<f64>,
+    pub classification: Option<RouteClass>,
 }
 
-impl RouteSpeedChart {
+impl RouteSpeedCard {
+    pub fn avg_scheduled_speed_kmh_display(&self) -> String {
+        fmt_speed_kmh(self.avg_scheduled_speed_mps)
+    }
+
+    pub fn avg_actual_speed_kmh_display(&self) -> String {
+        fmt_speed_kmh(self.avg_actual_speed_mps)
+    }
+
     pub fn avg_stop_spacing_class(&self) -> &'static str {
         match self.avg_stop_spacing_m {
             None => "none",
@@ -32,49 +47,10 @@ impl RouteSpeedChart {
     }
 }
 
-impl RouteSpeedCard {
-    pub fn avg_scheduled_speed_kmh_display(&self) -> String {
-        fmt_speed_kmh(self.avg_scheduled_speed_mps)
-    }
-
-    pub fn avg_actual_speed_kmh_display(&self) -> String {
-        fmt_speed_kmh(self.avg_actual_speed_mps)
-    }
-}
-
 fn fmt_speed_kmh(mps: Option<f64>) -> String {
     match mps {
         None => "—".to_string(),
         Some(s) => format!("{:.1}", s * 3.6),
-    }
-}
-
-pub struct RouteSpeedCard {
-    pub idx: usize,
-    pub agency_name: String,
-    pub agency_id: String,
-    pub route_id: String,
-    pub short_name: String,
-    pub long_name: String,
-    pub chart: RouteSpeedChart,
-    /// Sort key: unweighted mean of all non-None scheduled speed values across
-    /// all day types (weekday/Saturday/Sunday) and directions.
-    pub avg_scheduled_speed_mps: Option<f64>,
-    /// Sort key: unweighted mean of all non-None actual speed values across
-    /// all day types and directions. `None` when no actual speed data exists.
-    pub avg_actual_speed_mps: Option<f64>,
-    pub classification: Option<RouteClass>,
-}
-
-fn speed_kmh_json(mps: Option<f64>) -> serde_json::Value {
-    match mps {
-        Some(s) => {
-            let kmh = (s * 3.6 * 10.0).round() / 10.0;
-            serde_json::Number::from_f64(kmh)
-                .map(serde_json::Value::Number)
-                .unwrap_or(serde_json::Value::Null)
-        }
-        None => serde_json::Value::Null,
     }
 }
 
@@ -129,35 +105,6 @@ pub fn classify_by_spacing(avg_m: f64) -> RouteClass {
     }
 }
 
-fn combined_datasets(rows: &[RouteSpeedDayType]) -> serde_json::Value {
-    let weekday_sched = avg_speeds(rows.iter().map(|r| r.weekday_speed_mps));
-    let saturday_sched = avg_speeds(rows.iter().map(|r| r.saturday_speed_mps));
-    let sunday_sched = avg_speeds(rows.iter().map(|r| r.sunday_speed_mps));
-    let weekday_actual = avg_speeds(rows.iter().map(|r| r.actual_weekday_speed_mps));
-    let saturday_actual = avg_speeds(rows.iter().map(|r| r.actual_saturday_speed_mps));
-    let sunday_actual = avg_speeds(rows.iter().map(|r| r.actual_sunday_speed_mps));
-    serde_json::json!([
-        {
-            "label": "Scheduled",
-            "backgroundColor": "#1D4E89",
-            "data": [
-                speed_kmh_json(weekday_sched),
-                speed_kmh_json(saturday_sched),
-                speed_kmh_json(sunday_sched),
-            ]
-        },
-        {
-            "label": "Actual",
-            "backgroundColor": "#C8463A",
-            "data": [
-                speed_kmh_json(weekday_actual),
-                speed_kmh_json(saturday_actual),
-                speed_kmh_json(sunday_actual),
-            ]
-        },
-    ])
-}
-
 pub fn build_speed_cards(
     rows: Vec<RouteSpeedDayType>,
     agency_names: &HashMap<String, String>,
@@ -184,14 +131,8 @@ pub fn build_speed_cards(
                 r.actual_sunday_speed_mps,
             ]
         }));
-        let avg_spacing_m = avg_speeds(route_rows.iter().map(|r| r.avg_stop_spacing_m));
-        let classification = avg_spacing_m.map(classify_by_spacing);
-        let chart = RouteSpeedChart {
-            chart_id: format!("chart-{card_idx}"),
-            chart_json: serde_json::to_string(&combined_datasets(route_rows))
-                .unwrap_or_default(),
-            avg_stop_spacing_m: avg_spacing_m,
-        };
+        let avg_stop_spacing_m = avg_speeds(route_rows.iter().map(|r| r.avg_stop_spacing_m));
+        let classification = avg_stop_spacing_m.map(classify_by_spacing);
         cards.push(RouteSpeedCard {
             idx: card_idx,
             agency_name,
@@ -199,9 +140,9 @@ pub fn build_speed_cards(
             route_id: first.route_id.clone(),
             short_name: first.short_name.clone(),
             long_name: first.long_name.clone(),
-            chart,
             avg_scheduled_speed_mps,
             avg_actual_speed_mps,
+            avg_stop_spacing_m,
             classification,
         });
     }
@@ -233,18 +174,6 @@ mod tests {
             last_stop_name: None,
             avg_stop_spacing_m: None,
         }
-    }
-
-    #[test]
-    fn speed_kmh_json_converts_mps_to_kmh() {
-        // 10 m/s = 36 km/h
-        let v = speed_kmh_json(Some(10.0));
-        assert_eq!(v, serde_json::json!(36.0));
-    }
-
-    #[test]
-    fn speed_kmh_json_none_returns_null() {
-        assert_eq!(speed_kmh_json(None), serde_json::Value::Null);
     }
 
     #[test]
@@ -286,66 +215,6 @@ mod tests {
     fn build_speed_cards_empty_input_returns_empty() {
         let cards = build_speed_cards(vec![], &HashMap::new());
         assert!(cards.is_empty());
-    }
-
-    #[test]
-    fn build_speed_cards_produces_one_chart_per_route() {
-        let rows = vec![
-            make_row("stm", "R1", 0, Some(8.0)),
-            make_row("stm", "R1", 1, Some(7.5)),
-        ];
-        let names = HashMap::new();
-        let cards = build_speed_cards(rows, &names);
-        assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].chart.chart_id, "chart-0");
-    }
-
-    #[test]
-    fn build_speed_cards_chart_ids_are_unique_across_routes() {
-        let rows = vec![
-            make_row("stm", "R1", 0, Some(8.0)),
-            make_row("stm", "R2", 0, None),
-        ];
-        let names = HashMap::new();
-        let cards = build_speed_cards(rows, &names);
-        assert_ne!(cards[0].chart.chart_id, cards[1].chart.chart_id);
-    }
-
-    #[test]
-    fn combined_datasets_includes_scheduled_and_actual() {
-        let rows = vec![RouteSpeedDayType {
-            agency_id: "stm".to_string(),
-            route_id: "R1".to_string(),
-            short_name: "R1".to_string(),
-            long_name: "Route R1".to_string(),
-            direction_id: 0,
-            weekday_speed_mps: Some(10.0),
-            saturday_speed_mps: None,
-            sunday_speed_mps: None,
-            actual_weekday_speed_mps: Some(9.0),
-            actual_saturday_speed_mps: None,
-            actual_sunday_speed_mps: None,
-            last_stop_name: None,
-            avg_stop_spacing_m: None,
-        }];
-        let datasets = combined_datasets(&rows);
-        let arr = datasets.as_array().unwrap();
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0]["label"], "Scheduled");
-        assert_eq!(arr[1]["label"], "Actual");
-    }
-
-    #[test]
-    fn combined_datasets_averages_directions_per_day_type() {
-        // Two directions: weekday 8.0 and 6.0 → avg 7.0 m/s = 25.2 km/h
-        let rows = vec![
-            make_row("stm", "R1", 0, Some(8.0)),
-            make_row("stm", "R1", 1, Some(6.0)),
-        ];
-        let datasets = combined_datasets(&rows);
-        let arr = datasets.as_array().unwrap();
-        let weekday = arr[0]["data"][0].as_f64().unwrap();
-        assert!((weekday - 25.2).abs() < 0.05, "expected ~25.2 km/h, got {weekday}");
     }
 
     #[test]
@@ -460,22 +329,22 @@ mod tests {
     }
 
     #[test]
-    fn build_speed_cards_chart_carries_avg_stop_spacing() {
+    fn build_speed_cards_carries_avg_stop_spacing() {
         let mut row = make_row("stm", "R1", 0, Some(8.0));
         row.avg_stop_spacing_m = Some(450.0);
         let cards = build_speed_cards(vec![row], &HashMap::new());
-        assert_eq!(cards[0].chart.avg_stop_spacing_m, Some(450.0));
+        assert_eq!(cards[0].avg_stop_spacing_m, Some(450.0));
     }
 
     #[test]
-    fn build_speed_cards_chart_averages_stop_spacing_across_directions() {
+    fn build_speed_cards_averages_stop_spacing_across_directions() {
         // direction 0: 400 m, direction 1: 600 m → avg 500 m
         let mut row0 = make_row("stm", "R1", 0, Some(8.0));
         row0.avg_stop_spacing_m = Some(400.0);
         let mut row1 = make_row("stm", "R1", 1, Some(7.0));
         row1.avg_stop_spacing_m = Some(600.0);
         let cards = build_speed_cards(vec![row0, row1], &HashMap::new());
-        let spacing = cards[0].chart.avg_stop_spacing_m.unwrap();
+        let spacing = cards[0].avg_stop_spacing_m.unwrap();
         assert!((spacing - 500.0).abs() < 0.001, "expected 500.0, got {spacing}");
     }
 
@@ -547,62 +416,69 @@ mod tests {
         assert_eq!(cards[0].classification, Some(RouteClass::Rapid));
     }
 
-    fn chart_with_spacing(m: Option<f64>) -> RouteSpeedChart {
-        RouteSpeedChart {
-            chart_id: "x".into(),
-            chart_json: "[]".into(),
+    fn card_with_spacing(m: Option<f64>) -> RouteSpeedCard {
+        RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: None,
             avg_stop_spacing_m: m,
+            classification: None,
         }
     }
 
     #[test]
     fn spacing_class_none_when_no_data() {
-        assert_eq!(chart_with_spacing(None).avg_stop_spacing_class(), "none");
+        assert_eq!(card_with_spacing(None).avg_stop_spacing_class(), "none");
     }
 
     #[test]
     fn spacing_class_local_below_500m() {
-        assert_eq!(chart_with_spacing(Some(300.0)).avg_stop_spacing_class(), "local");
+        assert_eq!(card_with_spacing(Some(300.0)).avg_stop_spacing_class(), "local");
     }
 
     #[test]
     fn spacing_class_rapid_500_to_1500m() {
-        assert_eq!(chart_with_spacing(Some(800.0)).avg_stop_spacing_class(), "rapid");
+        assert_eq!(card_with_spacing(Some(800.0)).avg_stop_spacing_class(), "rapid");
     }
 
     #[test]
     fn spacing_class_express_1500m_and_above() {
-        assert_eq!(chart_with_spacing(Some(2000.0)).avg_stop_spacing_class(), "express");
+        assert_eq!(card_with_spacing(Some(2000.0)).avg_stop_spacing_class(), "express");
     }
 
     #[test]
     fn spacing_number_none() {
-        assert_eq!(chart_with_spacing(None).avg_stop_spacing_number(), "—");
+        assert_eq!(card_with_spacing(None).avg_stop_spacing_number(), "—");
     }
 
     #[test]
     fn spacing_number_metres() {
-        assert_eq!(chart_with_spacing(Some(342.0)).avg_stop_spacing_number(), "342");
+        assert_eq!(card_with_spacing(Some(342.0)).avg_stop_spacing_number(), "342");
     }
 
     #[test]
     fn spacing_number_kilometres() {
-        assert_eq!(chart_with_spacing(Some(1200.0)).avg_stop_spacing_number(), "1.2");
+        assert_eq!(card_with_spacing(Some(1200.0)).avg_stop_spacing_number(), "1.2");
     }
 
     #[test]
     fn spacing_unit_none() {
-        assert_eq!(chart_with_spacing(None).avg_stop_spacing_unit(), "");
+        assert_eq!(card_with_spacing(None).avg_stop_spacing_unit(), "");
     }
 
     #[test]
     fn spacing_unit_metres() {
-        assert_eq!(chart_with_spacing(Some(342.0)).avg_stop_spacing_unit(), "m");
+        assert_eq!(card_with_spacing(Some(342.0)).avg_stop_spacing_unit(), "m");
     }
 
     #[test]
     fn spacing_unit_kilometres() {
-        assert_eq!(chart_with_spacing(Some(1200.0)).avg_stop_spacing_unit(), "km");
+        assert_eq!(card_with_spacing(Some(1200.0)).avg_stop_spacing_unit(), "km");
     }
 
     #[test]
@@ -615,9 +491,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: "1".into(),
             long_name: "Route 1".into(),
-            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
             avg_scheduled_speed_mps: Some(10.0),
             avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
             classification: None,
         };
         assert_eq!(card.avg_scheduled_speed_kmh_display(), "36.0");
@@ -632,9 +508,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: "1".into(),
             long_name: "Route 1".into(),
-            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
             classification: None,
         };
         assert_eq!(card.avg_scheduled_speed_kmh_display(), "—");
@@ -650,9 +526,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: "1".into(),
             long_name: "Route 1".into(),
-            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: Some(5.0),
+            avg_stop_spacing_m: None,
             classification: None,
         };
         assert_eq!(card.avg_actual_speed_kmh_display(), "18.0");
@@ -667,9 +543,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: "1".into(),
             long_name: "Route 1".into(),
-            chart: RouteSpeedChart { chart_id: String::new(), chart_json: "[]".into(), avg_stop_spacing_m: None },
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
             classification: None,
         };
         assert_eq!(card.avg_actual_speed_kmh_display(), "—");

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -45,6 +45,14 @@ impl RouteSpeedCard {
             Some(_) => "m",
         }
     }
+
+    pub fn avg_stop_spacing_variant(&self) -> &'static str {
+        match self.avg_stop_spacing_m {
+            None => "neutral",
+            Some(m) if m < 300.0 => "bad",
+            Some(_) => "good",
+        }
+    }
 }
 
 fn fmt_speed_kmh(mps: Option<f64>) -> String {
@@ -479,6 +487,23 @@ mod tests {
     #[test]
     fn spacing_unit_kilometres() {
         assert_eq!(card_with_spacing(Some(1200.0)).avg_stop_spacing_unit(), "km");
+    }
+
+    #[test]
+    fn stop_spacing_variant_neutral_when_no_data() {
+        assert_eq!(card_with_spacing(None).avg_stop_spacing_variant(), "neutral");
+    }
+
+    #[test]
+    fn stop_spacing_variant_bad_below_300m() {
+        assert_eq!(card_with_spacing(Some(0.0)).avg_stop_spacing_variant(), "bad");
+        assert_eq!(card_with_spacing(Some(299.9)).avg_stop_spacing_variant(), "bad");
+    }
+
+    #[test]
+    fn stop_spacing_variant_good_at_or_above_300m() {
+        assert_eq!(card_with_spacing(Some(300.0)).avg_stop_spacing_variant(), "good");
+        assert_eq!(card_with_spacing(Some(1500.0)).avg_stop_spacing_variant(), "good");
     }
 
     #[test]

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -1,22 +1,13 @@
 use crate::speed::RouteSpeedDayType;
 use std::collections::HashMap;
 
-pub struct DirectionSpeedChart {
+pub struct RouteSpeedChart {
     pub chart_id: String,
-    pub title: String,
     pub chart_json: String,
     pub avg_stop_spacing_m: Option<f64>,
 }
 
-impl DirectionSpeedChart {
-    pub fn avg_stop_spacing_display(&self) -> String {
-        match self.avg_stop_spacing_m {
-            None => "—".to_string(),
-            Some(m) if m >= 1000.0 => format!("{:.1} km", m / 1000.0),
-            Some(m) => format!("{:.0} m", m),
-        }
-    }
-
+impl RouteSpeedChart {
     pub fn avg_stop_spacing_class(&self) -> &'static str {
         match self.avg_stop_spacing_m {
             None => "none",
@@ -48,10 +39,9 @@ pub struct RouteSpeedCard {
     pub route_id: String,
     pub short_name: String,
     pub long_name: String,
-    pub charts: Vec<DirectionSpeedChart>,
+    pub chart: RouteSpeedChart,
     /// Sort key: unweighted mean of all non-None scheduled speed values across
-    /// all day types (weekday/Saturday/Sunday) and directions. Routes with fewer
-    /// non-None slots contribute proportionally less weight.
+    /// all day types (weekday/Saturday/Sunday) and directions.
     pub avg_scheduled_speed_mps: Option<f64>,
     /// Sort key: unweighted mean of all non-None actual speed values across
     /// all day types and directions. `None` when no actual speed data exists.
@@ -122,24 +112,30 @@ pub fn classify_by_spacing(avg_m: f64) -> RouteClass {
     }
 }
 
-fn direction_datasets(row: &RouteSpeedDayType) -> serde_json::Value {
+fn combined_datasets(rows: &[RouteSpeedDayType]) -> serde_json::Value {
+    let weekday_sched = avg_speeds(rows.iter().map(|r| r.weekday_speed_mps));
+    let saturday_sched = avg_speeds(rows.iter().map(|r| r.saturday_speed_mps));
+    let sunday_sched = avg_speeds(rows.iter().map(|r| r.sunday_speed_mps));
+    let weekday_actual = avg_speeds(rows.iter().map(|r| r.actual_weekday_speed_mps));
+    let saturday_actual = avg_speeds(rows.iter().map(|r| r.actual_saturday_speed_mps));
+    let sunday_actual = avg_speeds(rows.iter().map(|r| r.actual_sunday_speed_mps));
     serde_json::json!([
         {
             "label": "Scheduled",
-            "backgroundColor": "#2980b9",
+            "backgroundColor": "#1D4E89",
             "data": [
-                speed_kmh_json(row.weekday_speed_mps),
-                speed_kmh_json(row.saturday_speed_mps),
-                speed_kmh_json(row.sunday_speed_mps),
+                speed_kmh_json(weekday_sched),
+                speed_kmh_json(saturday_sched),
+                speed_kmh_json(sunday_sched),
             ]
         },
         {
             "label": "Actual",
-            "backgroundColor": "#e67e22",
+            "backgroundColor": "#C8463A",
             "data": [
-                speed_kmh_json(row.actual_weekday_speed_mps),
-                speed_kmh_json(row.actual_saturday_speed_mps),
-                speed_kmh_json(row.actual_sunday_speed_mps),
+                speed_kmh_json(weekday_actual),
+                speed_kmh_json(saturday_actual),
+                speed_kmh_json(sunday_actual),
             ]
         },
     ])
@@ -157,18 +153,6 @@ pub fn build_speed_cards(
             .cloned()
             .unwrap_or_else(|| first.agency_id.clone());
         let card_idx = cards.len();
-        let charts: Vec<DirectionSpeedChart> = route_rows
-            .iter()
-            .map(|row| DirectionSpeedChart {
-                chart_id: format!("chart-{card_idx}-{}", row.direction_id),
-                title: row
-                    .last_stop_name
-                    .clone()
-                    .unwrap_or_else(|| super::direction_label(row.direction_id).to_string()),
-                chart_json: serde_json::to_string(&direction_datasets(row)).unwrap_or_default(),
-                avg_stop_spacing_m: row.avg_stop_spacing_m,
-            })
-            .collect();
         let avg_scheduled_speed_mps = avg_speeds(route_rows.iter().flat_map(|r| {
             [
                 r.weekday_speed_mps,
@@ -183,8 +167,14 @@ pub fn build_speed_cards(
                 r.actual_sunday_speed_mps,
             ]
         }));
-        let avg_spacing_m = avg_speeds(charts.iter().map(|c| c.avg_stop_spacing_m));
+        let avg_spacing_m = avg_speeds(route_rows.iter().map(|r| r.avg_stop_spacing_m));
         let classification = avg_spacing_m.map(classify_by_spacing);
+        let chart = RouteSpeedChart {
+            chart_id: format!("chart-{card_idx}"),
+            chart_json: serde_json::to_string(&combined_datasets(route_rows))
+                .unwrap_or_default(),
+            avg_stop_spacing_m: avg_spacing_m,
+        };
         cards.push(RouteSpeedCard {
             idx: card_idx,
             agency_name,
@@ -192,7 +182,7 @@ pub fn build_speed_cards(
             route_id: first.route_id.clone(),
             short_name: first.short_name.clone(),
             long_name: first.long_name.clone(),
-            charts,
+            chart,
             avg_scheduled_speed_mps,
             avg_actual_speed_mps,
             classification,
@@ -282,8 +272,31 @@ mod tests {
     }
 
     #[test]
-    fn direction_datasets_includes_scheduled_and_actual() {
-        let row = RouteSpeedDayType {
+    fn build_speed_cards_produces_one_chart_per_route() {
+        let rows = vec![
+            make_row("stm", "R1", 0, Some(8.0)),
+            make_row("stm", "R1", 1, Some(7.5)),
+        ];
+        let names = HashMap::new();
+        let cards = build_speed_cards(rows, &names);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].chart.chart_id, "chart-0");
+    }
+
+    #[test]
+    fn build_speed_cards_chart_ids_are_unique_across_routes() {
+        let rows = vec![
+            make_row("stm", "R1", 0, Some(8.0)),
+            make_row("stm", "R2", 0, None),
+        ];
+        let names = HashMap::new();
+        let cards = build_speed_cards(rows, &names);
+        assert_ne!(cards[0].chart.chart_id, cards[1].chart.chart_id);
+    }
+
+    #[test]
+    fn combined_datasets_includes_scheduled_and_actual() {
+        let rows = vec![RouteSpeedDayType {
             agency_id: "stm".to_string(),
             route_id: "R1".to_string(),
             short_name: "R1".to_string(),
@@ -297,59 +310,29 @@ mod tests {
             actual_sunday_speed_mps: None,
             last_stop_name: None,
             avg_stop_spacing_m: None,
-        };
-        let datasets = direction_datasets(&row);
+        }];
+        let datasets = combined_datasets(&rows);
         let arr = datasets.as_array().unwrap();
         assert_eq!(arr.len(), 2);
         assert_eq!(arr[0]["label"], "Scheduled");
-        assert_eq!(arr[0]["backgroundColor"], "#2980b9");
         assert_eq!(arr[1]["label"], "Actual");
-        assert_eq!(arr[1]["backgroundColor"], "#e67e22");
     }
 
     #[test]
-    fn build_speed_cards_single_direction_produces_one_chart() {
-        let rows = vec![make_row("stm", "R1", 0, Some(8.0))];
-        let names = HashMap::new();
-        let cards = build_speed_cards(rows, &names);
-        assert_eq!(cards[0].charts.len(), 1);
-        assert_eq!(cards[0].charts[0].title, "Outbound");
-    }
-
-    #[test]
-    fn build_speed_cards_both_directions_produce_two_charts() {
+    fn combined_datasets_averages_directions_per_day_type() {
+        // Two directions: weekday 8.0 and 6.0 → avg 7.0 m/s = 25.2 km/h
         let rows = vec![
             make_row("stm", "R1", 0, Some(8.0)),
-            make_row("stm", "R1", 1, Some(7.5)),
+            make_row("stm", "R1", 1, Some(6.0)),
         ];
-        let names = HashMap::new();
-        let cards = build_speed_cards(rows, &names);
-        assert_eq!(cards[0].charts.len(), 2);
-        assert_eq!(cards[0].charts[0].title, "Outbound");
-        assert_eq!(cards[0].charts[1].title, "Inbound");
-    }
-
-    #[test]
-    fn build_speed_cards_chart_ids_are_unique() {
-        let rows = vec![
-            make_row("stm", "R1", 0, Some(8.0)),
-            make_row("stm", "R1", 1, Some(7.5)),
-            make_row("stm", "R2", 0, None),
-        ];
-        let names = HashMap::new();
-        let cards = build_speed_cards(rows, &names);
-        let ids: Vec<&str> = cards
-            .iter()
-            .flat_map(|c| c.charts.iter().map(|ch| ch.chart_id.as_str()))
-            .collect();
-        let unique: std::collections::HashSet<_> = ids.iter().collect();
-        assert_eq!(ids.len(), unique.len(), "chart IDs must be globally unique");
+        let datasets = combined_datasets(&rows);
+        let arr = datasets.as_array().unwrap();
+        let weekday = arr[0]["data"][0].as_f64().unwrap();
+        assert!((weekday - 25.2).abs() < 0.05, "expected ~25.2 km/h, got {weekday}");
     }
 
     #[test]
     fn build_speed_cards_handles_route_ids_not_in_lexicographic_order() {
-        // SQL sorts by short_name, not route_id. Route "uuid-z" (short_name "1") comes
-        // before "uuid-a" (short_name "2") even though "uuid-z" > "uuid-a" lexicographically.
         let rows = vec![
             make_row("stm", "uuid-z", 0, Some(8.0)),
             make_row("stm", "uuid-a", 0, Some(7.0)),
@@ -454,7 +437,6 @@ mod tests {
 
     #[test]
     fn build_speed_cards_avg_scheduled_is_none_when_all_scheduled_speeds_none() {
-        // make_row sets weekday to None and saturday/sunday are always None
         let rows = vec![make_row("stm", "R1", 0, None)];
         let cards = build_speed_cards(rows, &HashMap::new());
         assert!(cards[0].avg_scheduled_speed_mps.is_none());
@@ -465,28 +447,19 @@ mod tests {
         let mut row = make_row("stm", "R1", 0, Some(8.0));
         row.avg_stop_spacing_m = Some(450.0);
         let cards = build_speed_cards(vec![row], &HashMap::new());
-        assert_eq!(cards[0].charts[0].avg_stop_spacing_m, Some(450.0));
+        assert_eq!(cards[0].chart.avg_stop_spacing_m, Some(450.0));
     }
 
     #[test]
-    fn build_speed_cards_uses_last_stop_name_as_chart_title() {
-        let rows = vec![RouteSpeedDayType {
-            agency_id: "stm".into(),
-            route_id: "R1".into(),
-            short_name: "R1".into(),
-            long_name: "Route R1".into(),
-            direction_id: 0,
-            weekday_speed_mps: Some(8.0),
-            saturday_speed_mps: None,
-            sunday_speed_mps: None,
-            actual_weekday_speed_mps: None,
-            actual_saturday_speed_mps: None,
-            actual_sunday_speed_mps: None,
-            last_stop_name: Some("Downtown".to_string()),
-            avg_stop_spacing_m: None,
-        }];
-        let cards = build_speed_cards(rows, &HashMap::new());
-        assert_eq!(cards[0].charts[0].title, "Downtown");
+    fn build_speed_cards_chart_averages_stop_spacing_across_directions() {
+        // direction 0: 400 m, direction 1: 600 m → avg 500 m
+        let mut row0 = make_row("stm", "R1", 0, Some(8.0));
+        row0.avg_stop_spacing_m = Some(400.0);
+        let mut row1 = make_row("stm", "R1", 1, Some(7.0));
+        row1.avg_stop_spacing_m = Some(600.0);
+        let cards = build_speed_cards(vec![row0, row1], &HashMap::new());
+        let spacing = cards[0].chart.avg_stop_spacing_m.unwrap();
+        assert!((spacing - 500.0).abs() < 0.001, "expected 500.0, got {spacing}");
     }
 
     #[test]
@@ -541,7 +514,6 @@ mod tests {
 
     #[test]
     fn build_speed_cards_classification_is_none_when_no_spacing_data() {
-        // make_row sets avg_stop_spacing_m = None
         let rows = vec![make_row("stm", "R1", 0, Some(8.0))];
         let cards = build_speed_cards(rows, &HashMap::new());
         assert!(cards[0].classification.is_none());
@@ -549,7 +521,7 @@ mod tests {
 
     #[test]
     fn build_speed_cards_classification_averages_across_directions() {
-        // direction 0: 400 m (Local Bus), direction 1: 600 m (Rapid) → avg 500 m → Rapid
+        // direction 0: 400 m (Local), direction 1: 600 m (Rapid) → avg 500 m → Rapid
         let mut row0 = make_row("stm", "R1", 0, Some(8.0));
         row0.avg_stop_spacing_m = Some(400.0);
         let mut row1 = make_row("stm", "R1", 1, Some(7.0));
@@ -558,10 +530,9 @@ mod tests {
         assert_eq!(cards[0].classification, Some(RouteClass::Rapid));
     }
 
-    fn chart_with_spacing(m: Option<f64>) -> DirectionSpeedChart {
-        DirectionSpeedChart {
+    fn chart_with_spacing(m: Option<f64>) -> RouteSpeedChart {
+        RouteSpeedChart {
             chart_id: "x".into(),
-            title: "T".into(),
             chart_json: "[]".into(),
             avg_stop_spacing_m: m,
         }

--- a/src/speed/mod.rs
+++ b/src/speed/mod.rs
@@ -7,7 +7,7 @@ use crate::db::Database;
 
 pub mod card;
 pub use card::{
-    RouteSpeedChart, RouteClass, RouteSpeedCard, build_speed_cards, classify_by_spacing,
+    RouteClass, RouteSpeedCard, build_speed_cards, classify_by_spacing,
 };
 
 pub(crate) fn direction_label(direction_id: i64) -> &'static str {

--- a/src/speed/mod.rs
+++ b/src/speed/mod.rs
@@ -7,7 +7,7 @@ use crate::db::Database;
 
 pub mod card;
 pub use card::{
-    DirectionSpeedChart, RouteClass, RouteSpeedCard, build_speed_cards, classify_by_spacing,
+    RouteSpeedChart, RouteClass, RouteSpeedCard, build_speed_cards, classify_by_spacing,
 };
 
 pub(crate) fn direction_label(direction_id: i64) -> &'static str {

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -631,15 +631,7 @@ pub async fn api_route_speed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::speed::{RouteSpeedCard, RouteSpeedChart};
-
-    fn empty_chart() -> RouteSpeedChart {
-        RouteSpeedChart {
-            chart_id: String::new(),
-            chart_json: "[]".into(),
-            avg_stop_spacing_m: None,
-        }
-    }
+    use crate::speed::RouteSpeedCard;
 
     fn card(short_name: &str, scheduled: f64, actual: Option<f64>) -> RouteSpeedCard {
         RouteSpeedCard {
@@ -649,9 +641,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            chart: empty_chart(),
             avg_scheduled_speed_mps: Some(scheduled),
             avg_actual_speed_mps: actual,
+            avg_stop_spacing_m: None,
             classification: None,
         }
     }
@@ -664,9 +656,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            chart: empty_chart(),
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
             classification: None,
         }
     }
@@ -733,9 +725,9 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            chart: empty_chart(),
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
             classification: class,
         }
     }

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -631,7 +631,15 @@ pub async fn api_route_speed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::speed::RouteSpeedCard;
+    use crate::speed::{RouteSpeedCard, RouteSpeedChart};
+
+    fn empty_chart() -> RouteSpeedChart {
+        RouteSpeedChart {
+            chart_id: String::new(),
+            chart_json: "[]".into(),
+            avg_stop_spacing_m: None,
+        }
+    }
 
     fn card(short_name: &str, scheduled: f64, actual: Option<f64>) -> RouteSpeedCard {
         RouteSpeedCard {
@@ -641,7 +649,7 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            charts: vec![],
+            chart: empty_chart(),
             avg_scheduled_speed_mps: Some(scheduled),
             avg_actual_speed_mps: actual,
             classification: None,
@@ -656,7 +664,7 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            charts: vec![],
+            chart: empty_chart(),
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
             classification: None,
@@ -725,7 +733,7 @@ mod tests {
             route_id: "R1".into(),
             short_name: short_name.into(),
             long_name: short_name.into(),
-            charts: vec![],
+            chart: empty_chart(),
             avg_scheduled_speed_mps: None,
             avg_actual_speed_mps: None,
             classification: class,

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1006,8 +1006,8 @@ mod e2e_tests {
             "speed page HTML should contain 'Rapid' badge text"
         );
         assert!(
-            html.contains("badge--rapid"),
-            "speed page HTML should contain 'badge--rapid' CSS class"
+            html.contains("badge--neutral"),
+            "speed page HTML should contain 'badge--neutral' CSS class for route classification"
         );
     }
 
@@ -1281,8 +1281,8 @@ mod e2e_tests {
             "detail page HTML should contain 'Rapid' badge text"
         );
         assert!(
-            html.contains("badge--rapid"),
-            "detail page HTML should contain 'badge--rapid' CSS class"
+            html.contains("badge--neutral"),
+            "detail page HTML should contain 'badge--neutral' CSS class for route classification"
         );
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -422,7 +422,7 @@
                     <rect x="4" y="5" width="34" height="32" rx="7" fill="#C8463A"/>
                     <path d="M12 27L18 21L23 25L31 15" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M12 14H21" stroke="#8fd6bd" stroke-width="3" stroke-linecap="round"/>
-                    <circle cx="31" cy="15" r="3" fill="#f0b84b"/>
+                    <circle cx="31" cy="15" r="3" fill="#E8A020"/>
                 </svg>
             </div>
             <span class="logo-text">Mobili<span>spect</span><span class="logo-region">{% block region_name %}{% endblock %}</span></span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,8 +42,8 @@
           --ink-900: #EDE8E0;
           --ink-800: #CCC7C0;
           --ink-700: #B5AFA6;
-          --ink-500: #7A7470;
-          --ink-400: #4E4844;
+          --ink-500: #9E9890;
+          --ink-400: #8C8680;
           --paper: #0D0B09;
           --surface: #1E1A16;
           --surface-muted: #161310;

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,10 @@
           --civic-red: #C8463A;
           --civic-red-bg: #F9DDD9;
           --link-blue: #1D4E89;
+          --link-blue-hover: #163A67;
           --link-blue-bg: #D0E0F3;
+          --express-bg: #F0E8FF;
+          --express-fg: #6B21D9;
           --shadow-sm: 0 1px 2px rgb(26 24 20 / 0.06);
           --shadow: 0 8px 24px rgb(26 24 20 / 0.10);
           --radius: 8px;
@@ -53,7 +56,10 @@
           --civic-red: #D95045;
           --civic-red-bg: rgba(217,80,69,0.15);
           --link-blue: #5A94CC;
+          --link-blue-hover: #4A80B8;
           --link-blue-bg: rgba(90,148,204,0.15);
+          --express-bg: rgba(107,33,217,0.18);
+          --express-fg: #B08AFF;
           --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.3);
           --shadow: 0 8px 24px rgb(0 0 0 / 0.4);
         }
@@ -65,7 +71,8 @@
         }
 
         *, *::before, *::after {
-            transition: background-color 0.15s ease, border-color 0.15s ease, color 0.05s ease;
+            transition: background-color 0.15s ease, border-color 0.15s ease,
+                        color 0.05s ease, box-shadow 0.15s ease;
         }
 
         body {
@@ -172,7 +179,7 @@
             font-weight: 600;
             font-size: 0.875rem;
             cursor: pointer;
-            transition: all 0.2s;
+            transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
             text-decoration: none;
             border: none;
         }
@@ -183,7 +190,7 @@
         }
 
         .btn-primary:hover {
-            background-color: #245a85;
+            background-color: var(--link-blue-hover);
             transform: translateY(-1px);
         }
 
@@ -211,7 +218,7 @@
 
         .badge.yellow, .badge.status-watch {
             background-color: var(--civic-amber-bg);
-            color: #8a5a00;
+            color: var(--civic-amber);
         }
 
         .badge.red, .badge.status-bad {
@@ -226,7 +233,7 @@
 
         .badge--local  { background: var(--link-blue-bg); color: var(--link-blue); }
         .badge--rapid     { background: var(--civic-green-bg); color: var(--civic-green); }
-        .badge--express   { background: #f3e8ff; color: #7c3aed; }
+        .badge--express   { background: var(--express-bg); color: var(--express-fg); }
 
         .mono {
             font-family: 'Fira Code', monospace;
@@ -238,7 +245,7 @@
         }
 
         .status-watch, .yellow, .onpace, .warn {
-            color: #8a5a00;
+            color: var(--civic-amber);
         }
 
         .status-bad, .red, .gap-neg, .slower, .decline, .poor {
@@ -422,7 +429,7 @@
         </a>
         <nav>
             <a href="/" class="{% block nav_speed %}{% endblock %}">Speeds</a>
-            <button id="theme-toggle" onclick="toggleTheme()"
+            <button id="theme-toggle" type="button" aria-label="Toggle colour scheme" onclick="toggleTheme()"
               style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:rgba(255,255,255,0.7);border-radius:6px;padding:4px 10px;cursor:pointer;font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.05em;display:flex;align-items:center;gap:6px;">
               <span id="theme-icon">☀️</span><span id="theme-label">LIGHT</span>
             </button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -229,29 +229,6 @@
             font-weight: 600;
         }
 
-        .badge.green, .badge.status-good {
-            background-color: var(--civic-green-bg);
-            color: var(--civic-green);
-        }
-
-        .badge.yellow, .badge.status-watch {
-            background-color: var(--civic-amber-bg);
-            color: var(--civic-amber);
-        }
-
-        .badge.red, .badge.status-bad {
-            background-color: var(--civic-red-bg);
-            color: var(--civic-red);
-        }
-
-        .badge.none, .badge.status-none {
-            background-color: var(--surface-muted);
-            color: var(--ink-500);
-        }
-
-        .badge--local  { background: var(--link-blue-bg); color: var(--link-blue); }
-        .badge--rapid     { background: var(--civic-green-bg); color: var(--civic-green); }
-        .badge--express   { background: var(--express-bg); color: var(--express-fg); }
         .badge--good    { background: var(--civic-green-bg); color: var(--civic-green); }
         .badge--bad     { background: var(--civic-red-bg);   color: var(--civic-red); }
         .badge--mixed   { background: var(--civic-amber-bg); color: var(--civic-amber); }

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,7 +84,7 @@
         }
 
         header {
-            background-color: var(--ink-900);
+            background-color: var(--link-blue);
             color: white;
             padding: 0.85rem 1.5rem;
             display: flex;
@@ -143,7 +143,7 @@
         .logo-region {
             font-family: 'Fira Code', monospace;
             font-size: 0.6rem;
-            color: var(--ink-400);
+            color: rgba(255,255,255,0.5);
             font-weight: 400;
             letter-spacing: 0.04em;
             margin-left: 0.5rem;
@@ -156,7 +156,7 @@
         }
 
         nav a {
-            color: var(--ink-400);
+            color: rgba(255,255,255,0.6);
             text-decoration: none;
             font-size: 0.85rem;
             font-weight: 600;

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,31 +6,56 @@
     <title>{% block title %}Mobilispect — Transit Performance{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Jost:wght@300;400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
     <style>
         :root {
-            /* Civic Ledger Palette */
-            --ink-900: #17202c;
-            --ink-800: #1f2937;
-            --ink-700: #334155;
-            --ink-500: #627083;
-            --ink-400: #7b8796;
-            --paper: #f7f9fb;
-            --surface: #ffffff;
-            --surface-muted: #f1f5f9;
-            --line: #d8dee8;
-            --line-soft: #edf0f5;
-            --civic-green: #2d8f67;
-            --civic-green-bg: #e8f7ef;
-            --civic-amber: #f0b84b;
-            --civic-amber-bg: #fff4d8;
-            --civic-red: #c9483f;
-            --civic-red-bg: #fbe4e1;
-            --link-blue: #2f6f9f;
-            --link-blue-bg: #e7f1f7;
-            --shadow-sm: 0 1px 2px rgb(23 32 44 / 0.05);
-            --shadow: 0 8px 24px rgb(23 32 44 / 0.08);
-            --radius: 8px;
+          /* ── LUMINA tokens ─────────────────────── */
+          --ink-900: #1A1814;     /* was #17202c */
+          --ink-800: #3D3935;
+          --ink-700: #645F5A;
+          --ink-500: #888480;
+          --ink-400: #A8A49B;
+          --paper: #FAFAF7;
+          --surface: #FFFFFF;
+          --surface-muted: #F4F4EF;
+          --line: #E0DDD6;
+          --line-soft: #ECEAE4;
+          --civic-green: #3D9A6B;
+          --civic-green-bg: #D0F0E0;
+          --civic-amber: #E8A020;
+          --civic-amber-bg: #FDF0D0;
+          --civic-red: #C8463A;
+          --civic-red-bg: #F9DDD9;
+          --link-blue: #1D4E89;
+          --link-blue-bg: #D0E0F3;
+          --shadow-sm: 0 1px 2px rgb(26 24 20 / 0.06);
+          --shadow: 0 8px 24px rgb(26 24 20 / 0.10);
+          --radius: 8px;
+          /* ── transition helper ─────────────────── */
+          --transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        }
+
+        html.dark {
+          --ink-900: #EDE8E0;
+          --ink-800: #CCC7C0;
+          --ink-700: #B5AFA6;
+          --ink-500: #7A7470;
+          --ink-400: #4E4844;
+          --paper: #0D0B09;
+          --surface: #1E1A16;
+          --surface-muted: #161310;
+          --line: #352C22;
+          --line-soft: #272018;
+          --civic-green: #4DAA7B;
+          --civic-green-bg: rgba(77,170,123,0.15);
+          --civic-amber: #E8A82A;
+          --civic-amber-bg: rgba(232,168,42,0.15);
+          --civic-red: #D95045;
+          --civic-red-bg: rgba(217,80,69,0.15);
+          --link-blue: #5A94CC;
+          --link-blue-bg: rgba(90,148,204,0.15);
+          --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.3);
+          --shadow: 0 8px 24px rgb(0 0 0 / 0.4);
         }
 
         * {
@@ -39,8 +64,12 @@
             padding: 0;
         }
 
+        *, *::before, *::after {
+            transition: background-color 0.15s ease, border-color 0.15s ease, color 0.05s ease;
+        }
+
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            font-family: 'Jost', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
             background-color: var(--paper);
             color: var(--ink-900);
             line-height: 1.5;
@@ -72,7 +101,6 @@
         .logo-icon {
             width: 42px;
             height: 42px;
-            background: transparent;
             border-radius: 8px;
             display: flex;
             align-items: center;
@@ -201,7 +229,7 @@
         .badge--express   { background: #f3e8ff; color: #7c3aed; }
 
         .mono {
-            font-family: 'JetBrains Mono', monospace;
+            font-family: 'Fira Code', monospace;
             font-weight: 500;
         }
 
@@ -229,6 +257,9 @@
             font-size: 1.6rem;
             line-height: 1.2;
             color: var(--ink-900);
+            font-family: 'Cormorant Garamond', Georgia, serif;
+            font-weight: 300;
+            letter-spacing: -0.01em;
         }
         .page-subtitle {
             margin-top: 0.35rem;
@@ -261,6 +292,9 @@
             font-size: 2rem;
             font-weight: 700;
             font-variant-numeric: tabular-nums;
+            font-family: 'Cormorant Garamond', Georgia, serif;
+            font-weight: 300;
+            letter-spacing: -0.02em;
         }
         .filter-bar,
         .control-row {
@@ -335,10 +369,10 @@
             font-size: 0.9rem;
         }
         .data-table tr:hover td {
-            background: #fbfdff;
+            background: var(--surface-muted);
         }
         .route-id {
-            font-family: 'JetBrains Mono', monospace;
+            font-family: 'Fira Code', monospace;
             font-weight: 700;
             color: var(--ink-900);
         }
@@ -378,7 +412,7 @@
         <a href="/" class="logo">
             <div class="logo-icon">
                 <svg width="34" height="34" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <rect x="4" y="5" width="34" height="32" rx="7" fill="currentColor"/>
+                    <rect x="4" y="5" width="34" height="32" rx="7" fill="#C8463A"/>
                     <path d="M12 27L18 21L23 25L31 15" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M12 14H21" stroke="#8fd6bd" stroke-width="3" stroke-linecap="round"/>
                     <circle cx="31" cy="15" r="3" fill="#f0b84b"/>
@@ -388,6 +422,10 @@
         </a>
         <nav>
             <a href="/" class="{% block nav_speed %}{% endblock %}">Speeds</a>
+            <button id="theme-toggle" onclick="toggleTheme()"
+              style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:rgba(255,255,255,0.7);border-radius:6px;padding:4px 10px;cursor:pointer;font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.05em;display:flex;align-items:center;gap:6px;">
+              <span id="theme-icon">☀️</span><span id="theme-label">LIGHT</span>
+            </button>
         </nav>
     </header>
 
@@ -401,5 +439,24 @@
     </footer>
 
     {% block extra_scripts %}{% endblock %}
+    <script>
+function toggleTheme() {
+  const isDark = document.documentElement.classList.toggle('dark');
+  document.getElementById('theme-label').textContent = isDark ? 'DARK' : 'LIGHT';
+  document.getElementById('theme-icon').textContent  = isDark ? '🌙' : '☀️';
+  localStorage.setItem('lumina-theme', isDark ? 'dark' : 'light');
+}
+(function initTheme() {
+  const saved = localStorage.getItem('lumina-theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (saved === 'dark' || (!saved && prefersDark)) {
+    document.documentElement.classList.add('dark');
+    const lbl = document.getElementById('theme-label');
+    const ico = document.getElementById('theme-icon');
+    if (lbl) lbl.textContent = 'DARK';
+    if (ico) ico.textContent = '🌙';
+  }
+})();
+    </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,11 @@
           --radius: 8px;
           /* ── transition helper ─────────────────── */
           --transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+          /* ── alert variants ────────────────────── */
+          --al-info-bg: var(--link-blue-bg); --al-info-fg: var(--link-blue); --al-info-border: var(--link-blue);
+          --al-ok-bg: var(--civic-green-bg); --al-ok-fg: var(--civic-green); --al-ok-border: var(--civic-green);
+          --al-warn-bg: var(--civic-amber-bg); --al-warn-fg: var(--civic-amber); --al-warn-border: var(--civic-amber);
+          --al-err-bg: var(--civic-red-bg);  --al-err-fg: var(--civic-red);  --al-err-border: var(--civic-red);
         }
 
         html.dark {
@@ -247,6 +252,10 @@
         .badge--local  { background: var(--link-blue-bg); color: var(--link-blue); }
         .badge--rapid     { background: var(--civic-green-bg); color: var(--civic-green); }
         .badge--express   { background: var(--express-bg); color: var(--express-fg); }
+        .badge--good    { background: var(--civic-green-bg); color: var(--civic-green); }
+        .badge--bad     { background: var(--civic-red-bg);   color: var(--civic-red); }
+        .badge--mixed   { background: var(--civic-amber-bg); color: var(--civic-amber); }
+        .badge--neutral { background: var(--link-blue-bg);   color: var(--link-blue); }
 
         .mono {
             font-family: 'Fira Code', monospace;
@@ -424,6 +433,28 @@
         }
 
         /* Specific blocks */
+
+        /* Stat display — shared across speed cards and route detail */
+        .spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
+        .spacing-stat-num   { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }
+        .spacing-stat-unit  { font-size:1rem; color:var(--ink-400); }
+        .spacing-good       { color: var(--civic-green); }
+        .spacing-bad        { color: var(--civic-red); }
+        .spacing-mixed      { color: var(--civic-amber); }
+        .spacing-neutral    { color: var(--link-blue); }
+
+        /* Section label — Fira Code uppercase cinnabar */
+        .section-label { font-family:'Fira Code',monospace; font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--civic-red); margin-bottom:0.75rem; }
+        .section-label-badge { display:inline-block; background:var(--link-blue); color:white; font-size:0.68rem; padding:0.15rem 0.4rem; border-radius:3px; margin-left:0.5rem; vertical-align:middle; font-weight:600; text-transform:none; letter-spacing:0; }
+        .section-label-badge.outlier { background:var(--civic-amber); }
+        .section-label-badge.slow    { background:var(--civic-red); }
+
+        /* Alert variants */
+        .alert { padding:0.75rem 1rem; border-radius:var(--radius); border-left:3px solid; margin-bottom:1rem; font-size:0.875rem; }
+        .alert--info { background:var(--al-info-bg); color:var(--al-info-fg); border-left-color:var(--al-info-border); }
+        .alert--ok   { background:var(--al-ok-bg);   color:var(--al-ok-fg);   border-left-color:var(--al-ok-border); }
+        .alert--warn { background:var(--al-warn-bg); color:var(--al-warn-fg); border-left-color:var(--al-warn-border); }
+        .alert--err  { background:var(--al-err-bg);  color:var(--al-err-fg);  border-left-color:var(--al-err-border); }
     </style>
     {% block extra_head %}{% endblock %}
 </head>

--- a/templates/base.html
+++ b/templates/base.html
@@ -116,25 +116,38 @@
         }
 
         .logo-text {
-            font-size: 1.1rem;
-            font-weight: 700;
-            color: white;
             display: flex;
-            align-items: center;
-            letter-spacing: -0.02em;
-            gap: 0.25rem;
+            align-items: baseline;
+            gap: 0;
             line-height: 1.2;
         }
 
-        .logo-text > span {
-            color: var(--ink-400);
-            font-weight: 400;
+        .logo-mobili {
+            font-family: 'Cormorant Garamond', Georgia, serif;
+            font-style: italic;
+            font-weight: 300;
+            font-size: 1.25rem;
+            color: white;
+            letter-spacing: -0.01em;
+        }
+
+        .logo-spect {
+            font-family: 'Fira Code', monospace;
+            font-weight: 500;
+            font-size: 0.8rem;
+            color: var(--civic-red);
+            letter-spacing: -0.02em;
+            margin-bottom: 1px;
         }
 
         .logo-region {
-            font-size: 0.7rem;
+            font-family: 'Fira Code', monospace;
+            font-size: 0.6rem;
             color: var(--ink-400);
-            font-weight: 500;
+            font-weight: 400;
+            letter-spacing: 0.04em;
+            margin-left: 0.5rem;
+            margin-bottom: 1px;
         }
 
         nav {
@@ -418,14 +431,17 @@
     <header>
         <a href="/" class="logo">
             <div class="logo-icon">
-                <svg width="34" height="34" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <rect x="4" y="5" width="34" height="32" rx="7" fill="#C8463A"/>
-                    <path d="M12 27L18 21L23 25L31 15" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M12 14H21" stroke="#8fd6bd" stroke-width="3" stroke-linecap="round"/>
-                    <circle cx="31" cy="15" r="3" fill="#E8A020"/>
+                <svg width="34" height="34" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <rect x="0.75" y="0.75" width="54.5" height="54.5" rx="13" fill="#1A1814" stroke="#2A2420" stroke-width="0.5"/>
+                    <line x1="5" y1="28" x2="15" y2="28" stroke="#3D3733" stroke-width="2" stroke-linecap="round"/>
+                    <line x1="33" y1="28" x2="51" y2="28" stroke="#3D3733" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M15,28 C17,28 18,38 22,38 C26,38 24,14 28,14 C32,14 32,28 33,28" stroke="#C8463A" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+                    <circle cx="28" cy="28" r="15" stroke="#C8463A" stroke-width="0.8" stroke-opacity="0.4" stroke-dasharray="3.8 2.8"/>
+                    <circle cx="28" cy="14" r="3.5" fill="#C8463A"/>
+                    <circle cx="28" cy="14" r="1.5" fill="#F28070"/>
                 </svg>
             </div>
-            <span class="logo-text">Mobili<span>spect</span><span class="logo-region">{% block region_name %}{% endblock %}</span></span>
+            <span class="logo-text"><span class="logo-mobili">mobili</span><span class="logo-spect">spect</span><span class="logo-region">{% block region_name %}{% endblock %}</span></span>
         </a>
         <nav>
             <a href="/" class="{% block nav_speed %}{% endblock %}">Speeds</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% import "macros.html" as ui %}
+
 {% block title %}Mobilispect — Transit Performance{% endblock %}
 {% block region_name %}{{ region_name }}{% endblock %}
 {% block nav_dashboard %}active{% endblock %}
@@ -14,14 +16,8 @@
   </div>
 
   <div class="metric-grid">
-    <div class="metric-card">
-      <div class="metric-label">Routes monitored</div>
-      <div class="metric-value">{{ routes.len() }}</div>
-    </div>
-    <div class="metric-card">
-      <div class="metric-label">Period</div>
-      <div class="metric-value">{{ period_days }}d</div>
-    </div>
+    {{ ui::metric_card(label="Routes monitored", value=routes.len(), unit="") }}
+    {{ ui::metric_card(label="Period", value=period_days, unit="d") }}
   </div>
 
   <div class="filter-bar">
@@ -51,7 +47,7 @@
         <td>{{ route.on_time_display() }}</td>
         <td>{{ route.delay_display() }}</td>
         <td>{% if let Some(r) = route.trips_run %}{{ r }}{% else %}0{% endif %} / {% if let Some(t) = route.trips_total %}{{ t }}{% else %}0{% endif %}</td>
-        <td><span class="badge {{ route.status_class() }}">{{ route.status_label() }}</span></td>
+        <td>{{ ui::badge(variant=route.badge_variant(), label=route.status_label()) }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/hotspots.html
+++ b/templates/hotspots.html
@@ -49,7 +49,7 @@
     th { padding: 0.6rem 0.75rem; text-align: left; font-size: 0.72rem;
          text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-500); font-weight: 700; }
     td { padding: 0.6rem 0.75rem; border-top: 1px solid var(--line-soft); }
-    tr:hover td { background: #fbfdff; cursor: pointer; }
+    tr:hover td { background: var(--surface-muted); cursor: pointer; }
     .rank { color: var(--ink-400); font-size: 0.75rem; width: 24px; }
     .delay { font-weight: 600; }
     .obs { color: var(--ink-400); font-size: 0.75rem; }

--- a/templates/hotspots.html
+++ b/templates/hotspots.html
@@ -5,11 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mobilispect — Delay Hotspots</title>
   <meta name="region" content="{{ region_name }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <style>
+    :root {
+      --ink-900: #1A1814;
+      --ink-500: #888480;
+      --ink-400: #A8A49B;
+      --paper: #FAFAF7;
+      --surface: #FFFFFF;
+      --surface-muted: #F4F4EF;
+      --line: #E0DDD6;
+      --line-soft: #ECEAE4;
+      --civic-green: #3D9A6B;
+      --civic-amber: #E8A020;
+      --civic-red: #C8463A;
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    body { font-family: 'Jost', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
            background: var(--paper); color: var(--ink-900); display: flex; flex-direction: column; height: 100vh; }
     header { background: var(--ink-900); color: white; padding: 0.85rem 1.5rem;
              display: flex; justify-content: space-between; align-items: center; flex-shrink: 0;
@@ -98,11 +114,11 @@
     }).addTo(map);
 
     function delayColor(d) {
-      if (d === null) return '#2d8f67';
-      if (d >= 300) return '#c9483f';
-      if (d >= 60)  return '#f0b84b';
-      if (d > 0)    return '#f0b84b';
-      return '#2d8f67';
+      if (d === null) return '#3D9A6B';
+      if (d >= 300) return '#C8463A';
+      if (d >= 60)  return '#E8A020';
+      if (d > 0)    return '#E8A020';
+      return '#3D9A6B';
     }
 
     function delayLabel(d) {

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,27 @@
+{% macro badge(variant, label) %}
+<span class="badge badge--{{ variant }}">{{ label }}</span>
+{% endmacro badge %}
+
+{% macro stat(label, value, unit, variant) %}
+<div class="spacing-stat-label">{{ label }}</div>
+<div class="spacing-stat-num{% if variant != "" %} spacing-{{ variant }}{% endif %}">{{ value }}<span class="spacing-stat-unit">{{ unit }}</span></div>
+{% endmacro stat %}
+
+{% macro section_label(text) %}
+<div class="section-label">{{ text }}</div>
+{% endmacro section_label %}
+
+{% macro filter_pill(href, label, active) %}
+<a class="filter-pill{% if active %} active{% endif %}" href="{{ href }}">{{ label }}</a>
+{% endmacro filter_pill %}
+
+{% macro metric_card(label, value, unit) %}
+<div class="metric-card">
+  <div class="metric-label">{{ label }}</div>
+  <div class="metric-value">{{ value }}{{ unit }}</div>
+</div>
+{% endmacro metric_card %}
+
+{% macro alert(variant, message) %}
+<div class="alert alert--{{ variant }}">{{ message }}</div>
+{% endmacro alert %}

--- a/templates/report.html
+++ b/templates/report.html
@@ -4,25 +4,28 @@
   <meta charset="UTF-8">
   <title>Mobilispect — Transit Performance Report</title>
   <meta name="region" content="{{ region_name }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Jost:wght@300;400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: Georgia, serif; color: #111; padding: 1rem; max-width: 800px; margin: 0 auto; }
+    body { font-family: 'Jost', Georgia, sans-serif; color: #111; padding: 1rem; max-width: 800px; margin: 0 auto; }
     .report-brand { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; font-family: sans-serif; }
     .report-mark { width: 34px; height: 34px; }
-    .report-name { font-size: 1rem; font-weight: 800; color: #17202c; }
-    .report-kicker { margin-top: 0.1rem; color: #627083; font-size: 0.75rem; }
-    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
-    .subtitle { color: #555; font-size: 0.9rem; margin-bottom: 2rem; }
+    .report-name { font-size: 1rem; font-weight: 800; color: #1A1814; font-family: 'Jost', sans-serif; }
+    .report-kicker { margin-top: 0.1rem; color: #888480; font-size: 0.75rem; }
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; font-family: 'Cormorant Garamond', Georgia, serif; font-weight: 300; }
+    .subtitle { color: #888480; font-size: 0.9rem; margin-bottom: 2rem; }
     table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
     thead { border-bottom: 2px solid #111; }
     th { padding: 0.5rem 0.75rem; text-align: left; font-size: 0.8rem;
          text-transform: uppercase; letter-spacing: 0.05em; }
-    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd; font-size: 0.9rem; }
-    .route-id { font-family: 'JetBrains Mono', monospace; font-weight: bold; }
-    .poor { color: #c9483f; font-weight: bold; }
-    .ok   { color: #2d8f67; }
-    .warn { color: #8a5a00; }
-    .footer { margin-top: 3rem; font-size: 0.75rem; color: #888; border-top: 1px solid #ddd; padding-top: 1rem; }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #E0DDD6; font-size: 0.9rem; }
+    .route-id { font-family: 'Fira Code', monospace; font-weight: bold; }
+    .poor { color: #C8463A; font-weight: bold; }
+    .ok   { color: #3D9A6B; }
+    .warn { color: #E8A020; }
+    .footer { margin-top: 3rem; font-size: 0.75rem; color: #A8A49B; border-top: 1px solid #E0DDD6; padding-top: 1rem; }
 
     @media print {
       body { padding: 0; }
@@ -39,10 +42,10 @@
 
   <div class="report-brand">
     <svg class="report-mark" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <rect x="4" y="5" width="34" height="32" rx="7" fill="#17202c"/>
+      <rect x="4" y="5" width="34" height="32" rx="7" fill="#1A1814"/>
       <path d="M12 27L18 21L23 25L31 15" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M12 14H21" stroke="#17202c" stroke-width="3" stroke-linecap="round"/>
-      <circle cx="31" cy="15" r="3" fill="#17202c"/>
+      <path d="M12 14H21" stroke="#3D9A6B" stroke-width="3" stroke-linecap="round"/>
+      <circle cx="31" cy="15" r="3" fill="#C8463A"/>
     </svg>
     <div>
       <div class="report-name">Mobilispect</div>

--- a/templates/report.html
+++ b/templates/report.html
@@ -71,7 +71,7 @@
       <tr>
         <td><span class="route-id">{% if let Some(n) = agency_names.get(route.agency_id.as_str()) %}{{ n }} {% endif %}{{ route.short_name }}</span></td>
         <td>{{ route.long_name }}</td>
-        <td><span class="{{ route.status_class() }}">{{ route.on_time_display() }}</span></td>
+        <td>{{ route.on_time_display() }}</td>
         <td>{{ route.delay_display() }}</td>
         <td>{% if let Some(r) = route.trips_run %}{{ r }}{% else %}0{% endif %} / {% if let Some(t) = route.trips_total %}{{ t }}{% else %}0{% endif %}</td>
       </tr>

--- a/templates/route_detail.html
+++ b/templates/route_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "macros.html" as ui %}
 
 {% block title %}Mobilispect — Route {{ trend.short_name }}{% endblock %}
 {% block region_name %}{{ region_name }}{% endblock %}
@@ -26,7 +27,7 @@ canvas { width: 100% !important; }
       <h1 class="page-title">Route {{ trend.short_name }} — {{ trend.long_name }}</h1>
       <p class="page-subtitle">Speed and on-time trend evidence</p>
     </div>
-    <a class="filter-pill" href="/">← Back to dashboard</a>
+    {{ ui::filter_pill(href="/", label="← Back to dashboard", active=false) }}
   </div>
 
   <div class="callout">

--- a/templates/route_detail.html
+++ b/templates/route_detail.html
@@ -75,13 +75,13 @@ canvas { width: 100% !important; }
 
   new Chart(document.getElementById('speedChart'), {
     type: 'line',
-    data: { labels, datasets: [{ label: 'Speed km/h', data: speeds, ...lineOpts('#2f6f9f') }] },
+    data: { labels, datasets: [{ label: 'Speed km/h', data: speeds, ...lineOpts('#1D4E89') }] },
     options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: false } } },
   });
 
   new Chart(document.getElementById('ontimeChart'), {
     type: 'line',
-    data: { labels, datasets: [{ label: 'On-time %', data: ontimes, ...lineOpts('#2d8f67') }] },
+    data: { labels, datasets: [{ label: 'On-time %', data: ontimes, ...lineOpts('#3D9A6B') }] },
     options: { plugins: { legend: { display: false } }, scales: { y: { min: 0, max: 100 } } },
   });
 </script>

--- a/templates/route_speed_detail.html
+++ b/templates/route_speed_detail.html
@@ -151,8 +151,8 @@ function renderSpeedChart(canvasId, data) {
     data: {
       labels,
       datasets: [
-        { label: 'Actual', data: actual, ...lineOpts('#2f6f9f') },
-        { label: 'Scheduled', data: scheduled, ...scheduledLineOpts('#627083') },
+        { label: 'Actual', data: actual, ...lineOpts('#1D4E89') },
+        { label: 'Scheduled', data: scheduled, ...scheduledLineOpts('#888480') },
       ],
     },
     options: {

--- a/templates/route_speed_detail.html
+++ b/templates/route_speed_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "macros.html" as ui %}
 
 {% block title %}Mobilispect — Route {{ short_name }} Speed Detail{% endblock %}
 {% block region_name %}{{ region_name }}{% endblock %}
@@ -10,10 +11,6 @@
 .direction-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(560px, 100%), 1fr)); gap: 1.5rem; }
 .direction-header { background: var(--surface-muted); padding: 0.75rem 1.25rem; font-weight: 700; font-size: 0.95rem; color: var(--ink-700); border-bottom: 1px solid var(--line); }
 .direction-body { padding: 1.25rem; }
-.section-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-500); margin-bottom: 0.75rem; font-weight: 700; }
-.section-label-badge { display: inline-block; background: var(--link-blue); color: white; font-size: 0.68rem; padding: 0.15rem 0.4rem; border-radius: 3px; margin-left: 0.5rem; vertical-align: middle; font-weight: 600; text-transform: none; letter-spacing: 0; }
-.section-label-badge.outlier { background: var(--civic-amber); }
-.section-label-badge.slow { background: var(--civic-red); }
 .stop-strip-wrap { overflow-y: auto; padding-right: 0.5rem; margin-bottom: 0.5rem; max-height: 400px; }
 .stop-strip { display: flex; flex-direction: column; align-items: flex-start; min-height: max-content; padding: 0 4px; height: max-content; }
 .stop-node { display: flex; flex-direction: row; align-items: center; min-height: 48px; flex-shrink: 0; gap: 0.5rem; }
@@ -49,7 +46,7 @@ canvas { width: 100% !important; }
     </div>
     <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
       {% if let Some(class) = classification %}
-      <span class="badge badge--{{ class.css_class() }}">{{ class.label() }} · {{ class.speed_range() }}</span>
+      {{ ui::badge(variant="neutral", label=class.display_label()) }}
       {% endif %}
       <a class="filter-pill" href="/speed?agency={{ agency_id }}">← Back to speed overview</a>
     </div>
@@ -95,7 +92,7 @@ canvas { width: 100% !important; }
 
       <div class="section-divider"></div>
 
-      <div class="section-label">Speed trend — scheduled vs actual</div>
+      {{ ui::section_label(text="Speed trend — scheduled vs actual") }}
       <div class="speed-charts-stack">
         <div>
           <div class="speed-chart-title">Weekday</div>

--- a/templates/scorecard.html
+++ b/templates/scorecard.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "macros.html" as ui %}
 
 {% block title %}Mobilispect — Global Scorecard{% endblock %}
 {% block region_name %}{{ region_name }}{% endblock %}
@@ -13,10 +14,7 @@
   </div>
 
   <div class="metric-grid">
-    <div class="metric-card">
-      <div class="metric-label">Routes monitored</div>
-      <div class="metric-value">{{ routes.len() }}</div>
-    </div>
+    {{ ui::metric_card(label="Routes monitored", value=routes.len(), unit="") }}
     <div class="metric-card">
       <div class="metric-label">Meeting {{ floor_city }} floor</div>
       <div class="metric-value">{{ routes_meeting_floor }}</div>
@@ -74,7 +72,7 @@
         {% for bench in benchmarks %}
         <td><span class="{{ route.on_time_gap_class(bench.on_time_pct) }}">{{ route.on_time_gap_display(bench.on_time_pct) }}</span></td>
         {% endfor %}
-        <td><span class="badge {{ route.status_class(floor_pct, ceiling_pct) }}">{{ route.status_label(floor_pct, ceiling_pct) }}</span></td>
+        <td>{{ ui::badge(variant=route.badge_variant(floor_pct, ceiling_pct), label=route.status_label(floor_pct, ceiling_pct)) }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/speed.html
+++ b/templates/speed.html
@@ -5,7 +5,6 @@
 {% block nav_speed %}active{% endblock %}
 
 {% block extra_head %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js" defer></script>
 <style>
 .controls { margin-bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.4rem; }

--- a/templates/speed.html
+++ b/templates/speed.html
@@ -10,10 +10,6 @@
 .controls { margin-bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
 .card-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
 @media (max-width: 900px) { .card-grid { grid-template-columns: 1fr; } }
-.chart-row { display: flex; gap: 0.75rem; }
-.chart-col { flex: 1; min-width: 0; }
-.chart-col:only-child { max-width: 50%; margin: 0 auto; }
-.chart-title { font-size: 0.8rem; font-weight: 600; text-align: center; margin-bottom: 0.25rem; color: var(--ink-700); }
 .spacing-stat { text-align:center; margin-top:0.5rem; padding-top:0.5rem; border-top:1px solid var(--line-soft); }
 .spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
 .spacing-stat-num { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }

--- a/templates/speed.html
+++ b/templates/speed.html
@@ -10,14 +10,6 @@
 .controls { margin-bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
 .card-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
 @media (max-width: 900px) { .card-grid { grid-template-columns: 1fr; } }
-.spacing-stat { text-align:center; margin-top:0.5rem; padding-top:0.5rem; border-top:1px solid var(--line-soft); }
-.spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
-.spacing-stat-num { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }
-.spacing-stat-unit { font-size:1rem; color:var(--ink-400); }
-.spacing-local   { color: var(--link-blue); }
-.spacing-rapid   { color: var(--civic-green); }
-.spacing-express { color: var(--express-fg); }
-.spacing-none    { color: var(--ink-400); }
 .speed-loading {
   display: inline-flex;
   align-items: center;

--- a/templates/speed.html
+++ b/templates/speed.html
@@ -15,6 +15,14 @@
 .chart-col { flex: 1; min-width: 0; }
 .chart-col:only-child { max-width: 50%; margin: 0 auto; }
 .chart-title { font-size: 0.8rem; font-weight: 600; text-align: center; margin-bottom: 0.25rem; color: var(--ink-700); }
+.spacing-stat { text-align:center; margin-top:0.5rem; padding-top:0.5rem; border-top:1px solid var(--line-soft); }
+.spacing-stat-label { font-family:'Fira Code',monospace; font-size:0.58rem; letter-spacing:0.08em; color:var(--ink-400); text-transform:uppercase; margin-bottom:3px; }
+.spacing-stat-num { font-family:'Cormorant Garamond',Georgia,serif; font-weight:300; font-size:1.8rem; line-height:1; }
+.spacing-stat-unit { font-size:1rem; color:var(--ink-400); }
+.spacing-local   { color: var(--link-blue); }
+.spacing-rapid   { color: var(--civic-green); }
+.spacing-express { color: var(--express-fg); }
+.spacing-none    { color: var(--ink-400); }
 .speed-loading {
   display: inline-flex;
   align-items: center;

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -10,8 +10,16 @@
     <span class="badge badge--{{ class.css_class() }}">{{ class.label() }}</span>
     {% endif %}
   </div>
-  <div style="margin-top:0.75rem;">
-    <div class="spacing-stat">
+  <div style="margin-top:0.75rem;display:flex;gap:1.5rem;border-top:1px solid var(--line-soft);padding-top:0.75rem;">
+    <div>
+      <div class="spacing-stat-label">Scheduled</div>
+      <div class="spacing-stat-num">{{ card.avg_scheduled_speed_kmh_display() }}<span class="spacing-stat-unit"> km/h</span></div>
+    </div>
+    <div>
+      <div class="spacing-stat-label">Actual</div>
+      <div class="spacing-stat-num">{{ card.avg_actual_speed_kmh_display() }}<span class="spacing-stat-unit"> km/h</span></div>
+    </div>
+    <div style="margin-left:auto;">
       <div class="spacing-stat-label">Avg stop spacing</div>
       <div class="spacing-stat-num spacing-{{ card.avg_stop_spacing_class() }}">{{ card.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ card.avg_stop_spacing_unit() }}</span></div>
     </div>

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -1,3 +1,4 @@
+{% import "macros.html" as ui %}
 <a href="/routes/{{ card.agency_id }}/{{ card.route_id }}/speed"
    style="text-decoration: none; color: inherit; display: block;">
 <div class="card" style="padding:1rem 1.25rem;">
@@ -7,22 +8,13 @@
       <div style="margin-top:0.15rem;color:var(--ink-500);font-size:0.82rem;">{{ card.long_name }}</div>
     </div>
     {% if let Some(class) = card.classification %}
-    <span class="badge badge--{{ class.css_class() }}">{{ class.label() }}</span>
+    {{ ui::badge(variant="neutral", label=class.label()) }}
     {% endif %}
   </div>
   <div style="margin-top:0.75rem;display:flex;gap:1.5rem;border-top:1px solid var(--line-soft);padding-top:0.75rem;">
-    <div>
-      <div class="spacing-stat-label">Scheduled</div>
-      <div class="spacing-stat-num">{{ card.avg_scheduled_speed_kmh_display() }}<span class="spacing-stat-unit"> km/h</span></div>
-    </div>
-    <div>
-      <div class="spacing-stat-label">Actual</div>
-      <div class="spacing-stat-num">{{ card.avg_actual_speed_kmh_display() }}<span class="spacing-stat-unit"> km/h</span></div>
-    </div>
-    <div style="margin-left:auto;">
-      <div class="spacing-stat-label">Avg stop spacing</div>
-      <div class="spacing-stat-num spacing-{{ card.avg_stop_spacing_class() }}">{{ card.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ card.avg_stop_spacing_unit() }}</span></div>
-    </div>
+    <div>{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div>{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div style="margin-left:auto;">{{ ui::stat(label="Avg stop spacing", value=card.avg_stop_spacing_number(), unit=card.avg_stop_spacing_unit(), variant=card.avg_stop_spacing_variant()) }}</div>
   </div>
 </div>
 </a>

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -11,31 +11,10 @@
     {% endif %}
   </div>
   <div style="margin-top:0.75rem;">
-    <canvas id="{{ card.chart.chart_id }}" height="160"></canvas>
     <div class="spacing-stat">
       <div class="spacing-stat-label">Avg stop spacing</div>
-      <div class="spacing-stat-num spacing-{{ card.chart.avg_stop_spacing_class() }}">{{ card.chart.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ card.chart.avg_stop_spacing_unit() }}</span></div>
+      <div class="spacing-stat-num spacing-{{ card.avg_stop_spacing_class() }}">{{ card.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ card.avg_stop_spacing_unit() }}</span></div>
     </div>
   </div>
 </div>
 </a>
-<script>
-new Chart(document.getElementById('{{ card.chart.chart_id }}'), {
-  type: 'bar',
-  data: {
-    labels: ['Weekday', 'Saturday', 'Sunday'],
-    datasets: {{ card.chart.chart_json|safe }}
-  },
-  options: {
-    responsive: true,
-    plugins: {
-      legend: { position: 'top', labels: { boxWidth: 10, font: { size: 11 } } },
-      title: { display: true, text: 'Speed (km/h)' }
-    },
-    scales: {
-      y: { beginAtZero: true, title: { display: true, text: 'km/h' }, ticks: { font: { size: 10 } } },
-      x: { ticks: { font: { size: 10 } } }
-    }
-  }
-});
-</script>

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -15,7 +15,10 @@
     <div style="flex:1;min-width:0;">
       <div class="chart-title">{{ chart.title }}</div>
       <canvas id="{{ chart.chart_id }}" height="160"></canvas>
-      <div style="text-align:center;font-size:0.75rem;color:var(--ink-500);margin-top:0.25rem;">Avg stop spacing: {{ chart.avg_stop_spacing_display() }}</div>
+      <div class="spacing-stat">
+        <div class="spacing-stat-label">Avg stop spacing</div>
+        <div class="spacing-stat-num spacing-{{ chart.avg_stop_spacing_class() }}">{{ chart.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ chart.avg_stop_spacing_unit() }}</span></div>
+      </div>
     </div>
     {% endfor %}
   </div>

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -10,27 +10,21 @@
     <span class="badge badge--{{ class.css_class() }}">{{ class.label() }}</span>
     {% endif %}
   </div>
-  <div style="display:flex;gap:0.75rem;margin-top:0.75rem;">
-    {% for chart in &card.charts %}
-    <div style="flex:1;min-width:0;">
-      <div class="chart-title">{{ chart.title }}</div>
-      <canvas id="{{ chart.chart_id }}" height="160"></canvas>
-      <div class="spacing-stat">
-        <div class="spacing-stat-label">Avg stop spacing</div>
-        <div class="spacing-stat-num spacing-{{ chart.avg_stop_spacing_class() }}">{{ chart.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ chart.avg_stop_spacing_unit() }}</span></div>
-      </div>
+  <div style="margin-top:0.75rem;">
+    <canvas id="{{ card.chart.chart_id }}" height="160"></canvas>
+    <div class="spacing-stat">
+      <div class="spacing-stat-label">Avg stop spacing</div>
+      <div class="spacing-stat-num spacing-{{ card.chart.avg_stop_spacing_class() }}">{{ card.chart.avg_stop_spacing_number() }}<span class="spacing-stat-unit">{{ card.chart.avg_stop_spacing_unit() }}</span></div>
     </div>
-    {% endfor %}
   </div>
 </div>
 </a>
 <script>
-{% for chart in &card.charts %}
-new Chart(document.getElementById('{{ chart.chart_id }}'), {
+new Chart(document.getElementById('{{ card.chart.chart_id }}'), {
   type: 'bar',
   data: {
     labels: ['Weekday', 'Saturday', 'Sunday'],
-    datasets: {{ chart.chart_json|safe }}
+    datasets: {{ card.chart.chart_json|safe }}
   },
   options: {
     responsive: true,
@@ -44,5 +38,4 @@ new Chart(document.getElementById('{{ chart.chart_id }}'), {
     }
   }
 });
-{% endfor %}
 </script>


### PR DESCRIPTION
## Summary

- Created `templates/macros.html` with 6 reusable macros: `badge`, `stat`, `section_label`, `filter_pill`, `metric_card`, `alert`
- Migrated all templates (`speed_card`, `route_speed_detail`, `dashboard`, `scorecard`, `route_detail`) to use macros instead of inline component HTML
- Added semantic badge/stat variant classes (`good/bad/mixed/neutral`) to `base.html`; removed old color-word classes (`.badge.green/yellow/red`, `.badge--local/rapid/express`)
- Added `avg_stop_spacing_variant()` and `RouteClass::display_label()` to Rust; added `badge_variant()` to `RouteSummary` and `ScorecardRoute`; removed dead `status_class()` and `avg_stop_spacing_class()` methods

## Test Plan

- [ ] `cargo build` passes (Askama validates templates at compile time)
- [ ] `cargo test` — 152 tests pass; 5 pre-existing DB integration test failures remain unchanged
- [ ] Speed page shows route classification badges with `badge--neutral` class
- [ ] Dashboard status badges use semantic `good/bad/mixed/neutral` variants
- [ ] Scorecard status badges use semantic variants
- [ ] Route detail "← Back to dashboard" link renders via `filter_pill` macro
- [ ] Route speed detail shows cinnabar section labels and neutral classification badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)