### PR TITLE
feat(speed): speed colour coding, spacing sort, and chip UI

### DIFF
--- a/frontend/design-system.html
+++ b/frontend/design-system.html
@@ -292,6 +292,26 @@
       white-space: nowrap;
     }
 
+    /* ---- Chip ---- */
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      min-height: 2rem;
+      padding: 0.35rem 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--ink);
+      font-size: 0.84rem;
+      font-weight: 600;
+      text-decoration: none;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .chip:hover { border-color: var(--ox); color: var(--ox); }
+    .chip.active { background: var(--ox); border-color: var(--ox); color: white; }
+
     /* ---- Progress bar ---- */
     .progress { height: 4px; background: var(--border); border-radius: 2px; overflow: hidden; }
     .progress-fill { height: 100%; border-radius: 2px; transition: width 0.8s ease; }

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -46,6 +46,21 @@ impl RouteSpeedCard {
             Some(_) => "good",
         }
     }
+
+    pub fn actual_speed_variant(&self) -> &'static str {
+        match (self.classification, self.avg_actual_speed_mps) {
+            (Some(RouteClass::Local), Some(mps)) => {
+                if mps < 12.0 / 3.6 {
+                    "bad"
+                } else if mps <= 15.0 / 3.6 {
+                    "mixed"
+                } else {
+                    "good"
+                }
+            }
+            _ => "",
+        }
+    }
 }
 
 fn fmt_speed_kmh(mps: Option<f64>) -> String {
@@ -562,5 +577,78 @@ mod tests {
             classification: None,
         };
         assert_eq!(card.avg_actual_speed_kmh_display(), "—");
+    }
+
+    fn local_card_with_actual(mps: Option<f64>) -> RouteSpeedCard {
+        RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: mps,
+            avg_stop_spacing_m: None,
+            classification: Some(RouteClass::Local),
+        }
+    }
+
+    #[test]
+    fn actual_speed_variant_bad_below_12kmh_for_local_route() {
+        assert_eq!(local_card_with_actual(Some(11.0 / 3.6)).actual_speed_variant(), "bad");
+        assert_eq!(local_card_with_actual(Some(0.0)).actual_speed_variant(), "bad");
+    }
+
+    #[test]
+    fn actual_speed_variant_mixed_at_12_to_15_kmh_for_local_route() {
+        assert_eq!(local_card_with_actual(Some(12.0 / 3.6)).actual_speed_variant(), "mixed");
+        assert_eq!(local_card_with_actual(Some(13.5 / 3.6)).actual_speed_variant(), "mixed");
+        assert_eq!(local_card_with_actual(Some(15.0 / 3.6)).actual_speed_variant(), "mixed");
+    }
+
+    #[test]
+    fn actual_speed_variant_good_above_15kmh_for_local_route() {
+        assert_eq!(local_card_with_actual(Some(16.0 / 3.6)).actual_speed_variant(), "good");
+        assert_eq!(local_card_with_actual(Some(30.0 / 3.6)).actual_speed_variant(), "good");
+    }
+
+    #[test]
+    fn actual_speed_variant_empty_when_no_actual_data() {
+        assert_eq!(local_card_with_actual(None).actual_speed_variant(), "");
+    }
+
+    #[test]
+    fn actual_speed_variant_empty_for_non_local_routes() {
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: Some(5.0),
+            avg_stop_spacing_m: None,
+            classification: Some(RouteClass::Rapid),
+        };
+        assert_eq!(card.actual_speed_variant(), "");
+    }
+
+    #[test]
+    fn actual_speed_variant_empty_when_no_classification() {
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: Some(5.0),
+            avg_stop_spacing_m: None,
+            classification: None,
+        };
+        assert_eq!(card.actual_speed_variant(), "");
     }
 }

--- a/src/speed/card.rs
+++ b/src/speed/card.rs
@@ -47,8 +47,16 @@ impl RouteSpeedCard {
         }
     }
 
+    pub fn scheduled_speed_variant(&self) -> &'static str {
+        Self::local_speed_variant(self.classification, self.avg_scheduled_speed_mps)
+    }
+
     pub fn actual_speed_variant(&self) -> &'static str {
-        match (self.classification, self.avg_actual_speed_mps) {
+        Self::local_speed_variant(self.classification, self.avg_actual_speed_mps)
+    }
+
+    fn local_speed_variant(classification: Option<RouteClass>, mps: Option<f64>) -> &'static str {
+        match (classification, mps) {
             (Some(RouteClass::Local), Some(mps)) => {
                 if mps < 12.0 / 3.6 {
                     "bad"
@@ -577,6 +585,62 @@ mod tests {
             classification: None,
         };
         assert_eq!(card.avg_actual_speed_kmh_display(), "—");
+    }
+
+    fn local_card_with_scheduled(mps: Option<f64>) -> RouteSpeedCard {
+        RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: mps,
+            avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
+            classification: Some(RouteClass::Local),
+        }
+    }
+
+    #[test]
+    fn scheduled_speed_variant_bad_below_12kmh_for_local_route() {
+        assert_eq!(local_card_with_scheduled(Some(11.0 / 3.6)).scheduled_speed_variant(), "bad");
+        assert_eq!(local_card_with_scheduled(Some(0.0)).scheduled_speed_variant(), "bad");
+    }
+
+    #[test]
+    fn scheduled_speed_variant_mixed_at_12_to_15_kmh_for_local_route() {
+        assert_eq!(local_card_with_scheduled(Some(12.0 / 3.6)).scheduled_speed_variant(), "mixed");
+        assert_eq!(local_card_with_scheduled(Some(13.5 / 3.6)).scheduled_speed_variant(), "mixed");
+        assert_eq!(local_card_with_scheduled(Some(15.0 / 3.6)).scheduled_speed_variant(), "mixed");
+    }
+
+    #[test]
+    fn scheduled_speed_variant_good_above_15kmh_for_local_route() {
+        assert_eq!(local_card_with_scheduled(Some(16.0 / 3.6)).scheduled_speed_variant(), "good");
+        assert_eq!(local_card_with_scheduled(Some(30.0 / 3.6)).scheduled_speed_variant(), "good");
+    }
+
+    #[test]
+    fn scheduled_speed_variant_empty_when_no_data() {
+        assert_eq!(local_card_with_scheduled(None).scheduled_speed_variant(), "");
+    }
+
+    #[test]
+    fn scheduled_speed_variant_empty_for_non_local_routes() {
+        let card = RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_scheduled_speed_mps: Some(5.0),
+            avg_actual_speed_mps: None,
+            avg_stop_spacing_m: None,
+            classification: Some(RouteClass::Rapid),
+        };
+        assert_eq!(card.scheduled_speed_variant(), "");
     }
 
     fn local_card_with_actual(mps: Option<f64>) -> RouteSpeedCard {

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -421,6 +421,17 @@ fn sort_speed_cards(cards: &mut Vec<RouteSpeedCard>, sort: &str) {
                 (None, None) => a.short_name.cmp(&b.short_name),
             },
         ),
+        "spacing" => cards.sort_by(
+            |a, b| match (a.avg_stop_spacing_m, b.avg_stop_spacing_m) {
+                (Some(x), Some(y)) => x
+                    .partial_cmp(&y)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(a.short_name.cmp(&b.short_name)),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => a.short_name.cmp(&b.short_name),
+            },
+        ),
         _ => {} // "name" or unknown — preserve SQL order
     }
 }
@@ -459,6 +470,7 @@ pub async fn speed_page(
     let active_sort = match params.sort.as_deref() {
         Some("scheduled") => "scheduled",
         Some("actual") => "actual",
+        Some("spacing") => "spacing",
         _ => "name",
     }
     .to_string();
@@ -714,6 +726,53 @@ mod tests {
     fn sort_scheduled_breaks_ties_by_name() {
         let mut cards = vec![card("Z", 5.0, None), card("A", 5.0, None)];
         sort_speed_cards(&mut cards, "scheduled");
+        assert_eq!(cards[0].short_name, "A");
+    }
+
+    fn card_with_spacing(short_name: &str, spacing: Option<f64>) -> RouteSpeedCard {
+        RouteSpeedCard {
+            idx: 0,
+            agency_name: "A".into(),
+            agency_id: "a".into(),
+            route_id: "R1".into(),
+            short_name: short_name.into(),
+            long_name: short_name.into(),
+            avg_scheduled_speed_mps: None,
+            avg_actual_speed_mps: None,
+            avg_stop_spacing_m: spacing,
+            classification: None,
+        }
+    }
+
+    #[test]
+    fn sort_spacing_orders_ascending_by_stop_spacing() {
+        let mut cards = vec![
+            card_with_spacing("B", Some(800.0)),
+            card_with_spacing("A", Some(300.0)),
+        ];
+        sort_speed_cards(&mut cards, "spacing");
+        assert_eq!(cards[0].short_name, "A");
+        assert_eq!(cards[1].short_name, "B");
+    }
+
+    #[test]
+    fn sort_spacing_puts_none_last() {
+        let mut cards = vec![
+            card_with_spacing("A", None),
+            card_with_spacing("B", Some(500.0)),
+        ];
+        sort_speed_cards(&mut cards, "spacing");
+        assert_eq!(cards[0].short_name, "B");
+        assert_eq!(cards[1].short_name, "A");
+    }
+
+    #[test]
+    fn sort_spacing_breaks_ties_by_name() {
+        let mut cards = vec![
+            card_with_spacing("Z", Some(500.0)),
+            card_with_spacing("A", Some(500.0)),
+        ];
+        sort_speed_cards(&mut cards, "spacing");
         assert_eq!(cards[0].short_name, "A");
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -320,7 +320,7 @@
             text-transform: uppercase;
             letter-spacing: 0.04em;
         }
-        .filter-pill,
+        .chip,
         .filter-bar a,
         .control-row a {
             display: inline-flex;
@@ -329,7 +329,7 @@
             padding: 0.35rem 0.75rem;
             margin: 0.25rem 0;
             border: 1px solid var(--line);
-            border-radius: 999px;
+            border-radius: 6px;
             background: var(--surface);
             color: var(--ink-700);
             font-size: 0.84rem;
@@ -337,13 +337,13 @@
             text-decoration: none;
             box-shadow: var(--shadow-sm);
         }
-        .filter-pill:hover,
+        .chip:hover,
         .filter-bar a:hover,
         .control-row a:hover {
             border-color: var(--link-blue);
             color: var(--link-blue);
         }
-        .filter-pill.active,
+        .chip.active,
         .filter-bar a.active,
         .control-row a.active {
             background: var(--link-blue);

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -11,9 +11,9 @@
 <div class="section-label">{{ text }}</div>
 {% endmacro section_label %}
 
-{% macro filter_pill(href, label, active) %}
-<a class="filter-pill{% if active %} active{% endif %}" href="{{ href }}">{{ label }}</a>
-{% endmacro filter_pill %}
+{% macro chip(href, label, active) %}
+<a class="chip{% if active %} active{% endif %}" href="{{ href }}">{{ label }}</a>
+{% endmacro chip %}
 
 {% macro metric_card(label, value, unit) %}
 <div class="metric-card">

--- a/templates/route_detail.html
+++ b/templates/route_detail.html
@@ -27,7 +27,7 @@ canvas { width: 100% !important; }
       <h1 class="page-title">Route {{ trend.short_name }} — {{ trend.long_name }}</h1>
       <p class="page-subtitle">Speed and on-time trend evidence</p>
     </div>
-    {{ ui::filter_pill(href="/", label="← Back to dashboard", active=false) }}
+    {{ ui::chip(href="/", label="← Back to dashboard", active=false) }}
   </div>
 
   <div class="callout">

--- a/templates/route_speed_detail.html
+++ b/templates/route_speed_detail.html
@@ -48,7 +48,7 @@ canvas { width: 100% !important; }
       {% if let Some(class) = classification %}
       {{ ui::badge(variant="neutral", label=class.display_label()) }}
       {% endif %}
-      <a class="filter-pill" href="/speed?agency={{ agency_id }}">← Back to speed overview</a>
+      <a class="chip" href="/speed?agency={{ agency_id }}">← Back to speed overview</a>
     </div>
   </div>
 

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -12,7 +12,7 @@
     {% endif %}
   </div>
   <div style="margin-top:0.75rem;display:flex;gap:1.5rem;border-top:1px solid var(--line-soft);padding-top:0.75rem;">
-    <div>{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div>{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant=card.scheduled_speed_variant()) }}</div>
     <div>{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant=card.actual_speed_variant()) }}</div>
     <div style="margin-left:auto;">{{ ui::stat(label="Avg stop spacing", value=card.avg_stop_spacing_number(), unit=card.avg_stop_spacing_unit(), variant=card.avg_stop_spacing_variant()) }}</div>
   </div>

--- a/templates/speed_card.html
+++ b/templates/speed_card.html
@@ -13,7 +13,7 @@
   </div>
   <div style="margin-top:0.75rem;display:flex;gap:1.5rem;border-top:1px solid var(--line-soft);padding-top:0.75rem;">
     <div>{{ ui::stat(label="Scheduled", value=card.avg_scheduled_speed_kmh_display(), unit=" km/h", variant="") }}</div>
-    <div>{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant="") }}</div>
+    <div>{{ ui::stat(label="Actual", value=card.avg_actual_speed_kmh_display(), unit=" km/h", variant=card.actual_speed_variant()) }}</div>
     <div style="margin-left:auto;">{{ ui::stat(label="Avg stop spacing", value=card.avg_stop_spacing_number(), unit=card.avg_stop_spacing_unit(), variant=card.avg_stop_spacing_variant()) }}</div>
   </div>
 </div>

--- a/templates/speed_content.html
+++ b/templates/speed_content.html
@@ -39,6 +39,12 @@
        hx-swap="outerHTML"
        hx-push-url="true"
        class="{% if active_sort == "actual" %}active{% endif %}">Slowest actual</a>
+    <a href="/speed?sort=spacing{% if !active_agency.is_empty() %}&amp;agency={{ active_agency }}{% endif %}{% if !active_class.is_empty() %}&amp;class={{ active_class }}{% endif %}"
+       hx-get="/speed?sort=spacing{% if !active_agency.is_empty() %}&amp;agency={{ active_agency }}{% endif %}{% if !active_class.is_empty() %}&amp;class={{ active_class }}{% endif %}"
+       hx-target="#speed-content"
+       hx-swap="outerHTML"
+       hx-push-url="true"
+       class="{% if active_sort == "spacing" %}active{% endif %}">Closest stop spacing</a>
   </div>
 
   <div class="control-row" style="margin-bottom:1.5rem;">


### PR DESCRIPTION
## Summary

- Color-code scheduled and actual speed stats on local route cards (red < 12 km/h, orange 12–15, green > 15)
- Add sort by closest stop spacing to the speed overview
- Replace filter-pill component with chip (rectangular 6px radius vs full pill)

## Test plan

- [ ] Confirm red/orange/green colouring appears on local route speed cards for both scheduled and actual stats
- [ ] Confirm Rapid/Express cards show no colour on speed stats
- [ ] Confirm "Closest stop spacing" sort link appears and orders routes ascending by stop spacing
- [ ] Confirm chips render with rectangular corners across agency, sort, and class filter rows
- [ ] Confirm back-navigation chips on route detail and route speed detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)