### PR TITLE
feat: frequency per-day stats and route schedule cards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -qE 'git push|cargo publish'; then cargo test; fi",
+            "timeout": 120,
+            "statusMessage": "Running tests before push..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; [[ \"$f\" == *.rs ]] && cargo fmt 2>/dev/null || true; }",
+            "timeout": 30,
+            "statusMessage": "Formatting Rust..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -48,6 +48,9 @@ pub mod test_utils {
         .await
         .unwrap();
         db.migrate().await.unwrap();
-        TestDb { db, _container: container }
+        TestDb {
+            db,
+            _container: container,
+        }
     }
 }

--- a/crates/core/src/frequency/mod.rs
+++ b/crates/core/src/frequency/mod.rs
@@ -14,6 +14,11 @@ pub struct RouteHeadwayRow {
     pub weekday_headway_mins: Option<f64>,
     pub saturday_headway_mins: Option<f64>,
     pub sunday_headway_mins: Option<f64>,
+    pub min_headway_mins: Option<f64>,
+    pub max_headway_mins: Option<f64>,
+    pub service_start_secs: Option<i64>,
+    pub service_end_secs: Option<i64>,
+    pub trip_count: i64,
 }
 
 impl RouteHeadwayRow {
@@ -34,6 +39,33 @@ impl RouteHeadwayRow {
 
     pub fn sunday_display(&self) -> String {
         Self::headway_display(self.sunday_headway_mins)
+    }
+
+    pub fn min_headway_display(&self) -> String {
+        Self::headway_display(self.min_headway_mins)
+    }
+
+    pub fn max_headway_display(&self) -> String {
+        Self::headway_display(self.max_headway_mins)
+    }
+
+    pub fn trip_count_display(&self) -> String {
+        self.trip_count.to_string()
+    }
+
+    pub fn service_span_display(&self) -> String {
+        match (self.service_start_secs, self.service_end_secs) {
+            (Some(start), Some(end)) => {
+                format!("{}-{}", Self::time_display(start), Self::time_display(end))
+            }
+            _ => "—".to_string(),
+        }
+    }
+
+    fn time_display(secs: i64) -> String {
+        let hours = secs.div_euclid(3600);
+        let minutes = secs.rem_euclid(3600).div_euclid(60);
+        format!("{hours:02}:{minutes:02}")
     }
 
     pub fn headway_badge_variant(mins: Option<f64>) -> &'static str {
@@ -57,6 +89,14 @@ impl RouteHeadwayRow {
         Self::headway_badge_variant(self.sunday_headway_mins)
     }
 
+    pub fn min_headway_badge_variant(&self) -> &'static str {
+        Self::headway_badge_variant(self.min_headway_mins)
+    }
+
+    pub fn max_headway_badge_variant(&self) -> &'static str {
+        Self::headway_badge_variant(self.max_headway_mins)
+    }
+
     pub fn direction_label(&self) -> &'static str {
         match self.direction_id.as_i64() {
             0 => "Outbound",
@@ -77,16 +117,22 @@ pub async fn route_headways(
     agency_filter: Option<&AgencyId>,
 ) -> Result<Vec<RouteHeadwayRow>> {
     let sql = "WITH
-first_stop_dep AS (
-    SELECT DISTINCT ON (ss.agency_id, ss.trip_id)
+trip_times AS (
+    SELECT
         t.agency_id,
         t.route_id,
         COALESCE(t.direction_id, 0)                              AS direction_id,
-        (
+        t.trip_id,
+        MIN((
             SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
           + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
           + SPLIT_PART(ss.departure_time, ':', 3)::INT
-        )                                                        AS dep_secs,
+        )::BIGINT)                                               AS start_secs,
+        MAX((
+            SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
+          + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
+          + SPLIT_PART(ss.departure_time, ':', 3)::INT
+        )::BIGINT)                                               AS end_secs,
         (c.monday OR c.tuesday OR c.wednesday
          OR c.thursday OR c.friday)                             AS is_weekday,
         c.saturday                                               AS is_saturday,
@@ -98,47 +144,95 @@ first_stop_dep AS (
       ON ss.agency_id = t.agency_id AND ss.trip_id = t.trip_id
     WHERE (c.monday OR c.tuesday OR c.wednesday OR c.thursday
            OR c.friday OR c.saturday OR c.sunday)
-    ORDER BY ss.agency_id, ss.trip_id, ss.stop_sequence ASC
+    GROUP BY
+        t.agency_id,
+        t.route_id,
+        COALESCE(t.direction_id, 0),
+        t.trip_id,
+        is_weekday,
+        c.saturday,
+        c.sunday
 ),
 wd_gaps AS (
     SELECT agency_id, route_id, direction_id,
-        LEAD(dep_secs) OVER (
+        LEAD(start_secs) OVER (
             PARTITION BY agency_id, route_id, direction_id
-            ORDER BY dep_secs
-        ) - dep_secs AS gap_secs
-    FROM first_stop_dep
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
     WHERE is_weekday
 ),
 sat_gaps AS (
     SELECT agency_id, route_id, direction_id,
-        LEAD(dep_secs) OVER (
+        LEAD(start_secs) OVER (
             PARTITION BY agency_id, route_id, direction_id
-            ORDER BY dep_secs
-        ) - dep_secs AS gap_secs
-    FROM first_stop_dep
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
     WHERE is_saturday
 ),
 sun_gaps AS (
     SELECT agency_id, route_id, direction_id,
-        LEAD(dep_secs) OVER (
+        LEAD(start_secs) OVER (
             PARTITION BY agency_id, route_id, direction_id
-            ORDER BY dep_secs
-        ) - dep_secs AS gap_secs
-    FROM first_stop_dep
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
     WHERE is_sunday
+),
+wd_headways AS (
+    SELECT agency_id, route_id, direction_id,
+        AVG(gap_secs::double precision) / 60.0 AS weekday_headway_mins
+    FROM wd_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id, direction_id
+),
+sat_headways AS (
+    SELECT agency_id, route_id, direction_id,
+        AVG(gap_secs::double precision) / 60.0 AS saturday_headway_mins
+    FROM sat_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id, direction_id
+),
+sun_headways AS (
+    SELECT agency_id, route_id, direction_id,
+        AVG(gap_secs::double precision) / 60.0 AS sunday_headway_mins
+    FROM sun_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id, direction_id
+),
+all_gaps AS (
+    SELECT * FROM wd_gaps
+    UNION ALL
+    SELECT * FROM sat_gaps
+    UNION ALL
+    SELECT * FROM sun_gaps
+),
+gap_summary AS (
+    SELECT agency_id, route_id, direction_id,
+        MIN(gap_secs::double precision) / 60.0 AS min_headway_mins,
+        MAX(gap_secs::double precision) / 60.0 AS max_headway_mins
+    FROM all_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id, direction_id
+),
+service_summary AS (
+    SELECT agency_id, route_id, direction_id,
+        MIN(start_secs) AS service_start_secs,
+        MAX(end_secs) AS service_end_secs,
+        COUNT(*) AS trip_count
+    FROM trip_times
+    GROUP BY agency_id, route_id, direction_id
 ),
 route_dirs AS (
     SELECT DISTINCT
-        t.agency_id,
-        t.route_id,
+        tt.agency_id,
+        tt.route_id,
         r.short_name,
         r.long_name,
-        COALESCE(t.direction_id, 0) AS direction_id
-    FROM trips t
-    JOIN routes r ON r.agency_id = t.agency_id AND r.route_id = t.route_id
-    JOIN calendar c ON c.agency_id = t.agency_id AND c.service_id = t.service_id
-    WHERE (c.monday OR c.tuesday OR c.wednesday OR c.thursday
-           OR c.friday OR c.saturday OR c.sunday)
+        tt.direction_id
+    FROM trip_times tt
+    JOIN routes r ON r.agency_id = tt.agency_id AND r.route_id = tt.route_id
 )
 SELECT
     rd.agency_id,
@@ -146,38 +240,48 @@ SELECT
     rd.short_name,
     rd.long_name,
     rd.direction_id,
-    AVG(CASE WHEN wd.gap_secs > 0 THEN wd.gap_secs END) / 60.0
-        AS weekday_headway_mins,
-    AVG(CASE WHEN sat.gap_secs > 0 THEN sat.gap_secs END) / 60.0
-        AS saturday_headway_mins,
-    AVG(CASE WHEN sun.gap_secs > 0 THEN sun.gap_secs END) / 60.0
-        AS sunday_headway_mins
+    wd.weekday_headway_mins,
+    sat.saturday_headway_mins,
+    sun.sunday_headway_mins,
+    gs.min_headway_mins,
+    gs.max_headway_mins,
+    ss.service_start_secs,
+    ss.service_end_secs,
+    ss.trip_count
 FROM route_dirs rd
-LEFT JOIN wd_gaps wd
+LEFT JOIN wd_headways wd
   ON wd.agency_id = rd.agency_id
  AND wd.route_id  = rd.route_id
  AND wd.direction_id = rd.direction_id
-LEFT JOIN sat_gaps sat
+LEFT JOIN sat_headways sat
   ON sat.agency_id = rd.agency_id
  AND sat.route_id  = rd.route_id
  AND sat.direction_id = rd.direction_id
-LEFT JOIN sun_gaps sun
+LEFT JOIN sun_headways sun
   ON sun.agency_id = rd.agency_id
  AND sun.route_id  = rd.route_id
  AND sun.direction_id = rd.direction_id
+LEFT JOIN gap_summary gs
+  ON gs.agency_id = rd.agency_id
+ AND gs.route_id  = rd.route_id
+ AND gs.direction_id = rd.direction_id
+LEFT JOIN service_summary ss
+  ON ss.agency_id = rd.agency_id
+ AND ss.route_id  = rd.route_id
+ AND ss.direction_id = rd.direction_id
 WHERE ($1::text IS NULL OR rd.agency_id = $1)
-GROUP BY rd.agency_id, rd.route_id, rd.short_name, rd.long_name, rd.direction_id
-HAVING
-    AVG(CASE WHEN wd.gap_secs  > 0 THEN wd.gap_secs  END) IS NOT NULL
- OR AVG(CASE WHEN sat.gap_secs > 0 THEN sat.gap_secs END) IS NOT NULL
- OR AVG(CASE WHEN sun.gap_secs > 0 THEN sun.gap_secs END) IS NOT NULL
+  AND (
+      wd.weekday_headway_mins IS NOT NULL
+   OR sat.saturday_headway_mins IS NOT NULL
+   OR sun.sunday_headway_mins IS NOT NULL
+  )
 ORDER BY
     rd.agency_id,
     COALESCE(
-        AVG(CASE WHEN wd.gap_secs  > 0 THEN wd.gap_secs  END),
-        AVG(CASE WHEN sat.gap_secs > 0 THEN sat.gap_secs END),
-        AVG(CASE WHEN sun.gap_secs > 0 THEN sun.gap_secs END)
-    ) / 60.0 ASC NULLS LAST,
+        wd.weekday_headway_mins,
+        sat.saturday_headway_mins,
+        sun.sunday_headway_mins
+    ) ASC NULLS LAST,
     CASE WHEN rd.short_name ~ '^[0-9]+$'
          THEN rd.short_name::INTEGER ELSE NULL END NULLS LAST,
     rd.short_name,
@@ -242,6 +346,11 @@ mod tests {
             weekday_headway_mins: wd,
             saturday_headway_mins: sat,
             sunday_headway_mins: sun,
+            min_headway_mins: Some(5.0),
+            max_headway_mins: Some(30.0),
+            service_start_secs: Some(6 * 3600),
+            service_end_secs: Some(23 * 3600 + 30 * 60),
+            trip_count: 42,
         }
     }
 
@@ -280,5 +389,25 @@ mod tests {
     fn primary_headway_min_all_none() {
         let row = make_row(None, None, None);
         assert_eq!(row.primary_headway_min(), None);
+    }
+
+    #[test]
+    fn min_max_headway_display_formats_range() {
+        let row = make_row(Some(8.0), Some(15.0), Some(20.0));
+        assert_eq!(row.min_headway_display(), "5.0 min");
+        assert_eq!(row.max_headway_display(), "30.0 min");
+    }
+
+    #[test]
+    fn service_span_display_formats_times() {
+        let row = make_row(Some(8.0), Some(15.0), Some(20.0));
+        assert_eq!(row.service_span_display(), "06:00-23:30");
+    }
+
+    #[test]
+    fn service_span_display_wraps_after_midnight() {
+        let mut row = make_row(Some(8.0), Some(15.0), Some(20.0));
+        row.service_end_secs = Some(25 * 3600 + 15 * 60);
+        assert_eq!(row.service_span_display(), "06:00-25:15");
     }
 }

--- a/crates/core/src/frequency/mod.rs
+++ b/crates/core/src/frequency/mod.rs
@@ -13,11 +13,18 @@ pub struct RouteHeadwayRow {
     pub weekday_headway_mins: Option<f64>,
     pub saturday_headway_mins: Option<f64>,
     pub sunday_headway_mins: Option<f64>,
-    pub min_headway_mins: Option<f64>,
-    pub max_headway_mins: Option<f64>,
-    pub service_start_secs: Option<i64>,
-    pub service_end_secs: Option<i64>,
-    pub trip_count: i64,
+    pub weekday_top_decile_mins: Option<f64>,
+    pub weekday_max_headway_mins: Option<f64>,
+    pub weekday_service_start_secs: Option<i64>,
+    pub weekday_service_end_secs: Option<i64>,
+    pub saturday_top_decile_mins: Option<f64>,
+    pub saturday_max_headway_mins: Option<f64>,
+    pub saturday_service_start_secs: Option<i64>,
+    pub saturday_service_end_secs: Option<i64>,
+    pub sunday_top_decile_mins: Option<f64>,
+    pub sunday_max_headway_mins: Option<f64>,
+    pub sunday_service_start_secs: Option<i64>,
+    pub sunday_service_end_secs: Option<i64>,
 }
 
 impl RouteHeadwayRow {
@@ -40,22 +47,46 @@ impl RouteHeadwayRow {
         Self::headway_display(self.sunday_headway_mins)
     }
 
-    pub fn min_headway_display(&self) -> String {
-        Self::headway_display(self.min_headway_mins)
+    pub fn weekday_top_decile_display(&self) -> String {
+        Self::headway_display(self.weekday_top_decile_mins)
     }
 
-    pub fn max_headway_display(&self) -> String {
-        Self::headway_display(self.max_headway_mins)
+    pub fn weekday_max_headway_display(&self) -> String {
+        Self::headway_display(self.weekday_max_headway_mins)
     }
 
-    pub fn trip_count_display(&self) -> String {
-        self.trip_count.to_string()
+    pub fn saturday_top_decile_display(&self) -> String {
+        Self::headway_display(self.saturday_top_decile_mins)
     }
 
-    pub fn service_span_display(&self) -> String {
-        match (self.service_start_secs, self.service_end_secs) {
-            (Some(start), Some(end)) => {
-                format!("{}-{}", Self::time_display(start), Self::time_display(end))
+    pub fn saturday_max_headway_display(&self) -> String {
+        Self::headway_display(self.saturday_max_headway_mins)
+    }
+
+    pub fn sunday_top_decile_display(&self) -> String {
+        Self::headway_display(self.sunday_top_decile_mins)
+    }
+
+    pub fn sunday_max_headway_display(&self) -> String {
+        Self::headway_display(self.sunday_max_headway_mins)
+    }
+
+    pub fn weekday_service_span_display(&self) -> String {
+        Self::service_span(self.weekday_service_start_secs, self.weekday_service_end_secs)
+    }
+
+    pub fn saturday_service_span_display(&self) -> String {
+        Self::service_span(self.saturday_service_start_secs, self.saturday_service_end_secs)
+    }
+
+    pub fn sunday_service_span_display(&self) -> String {
+        Self::service_span(self.sunday_service_start_secs, self.sunday_service_end_secs)
+    }
+
+    pub fn service_span(start: Option<i64>, end: Option<i64>) -> String {
+        match (start, end) {
+            (Some(s), Some(e)) => {
+                format!("{}-{}", Self::time_display(s), Self::time_display(e))
             }
             _ => "—".to_string(),
         }
@@ -88,14 +119,6 @@ impl RouteHeadwayRow {
         Self::headway_badge_variant(self.sunday_headway_mins)
     }
 
-    pub fn min_headway_badge_variant(&self) -> &'static str {
-        Self::headway_badge_variant(self.min_headway_mins)
-    }
-
-    pub fn max_headway_badge_variant(&self) -> &'static str {
-        Self::headway_badge_variant(self.max_headway_mins)
-    }
-
     pub fn primary_headway_min(&self) -> Option<f64> {
         self.weekday_headway_mins
             .or(self.saturday_headway_mins)
@@ -114,6 +137,7 @@ trip_times AS (
         t.route_id,
         COALESCE(t.direction_id, 0)                              AS direction_id,
         t.trip_id,
+        t.service_id,
         MIN((
             SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
           + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
@@ -140,6 +164,7 @@ trip_times AS (
         t.route_id,
         COALESCE(t.direction_id, 0),
         t.trip_id,
+        t.service_id,
         is_weekday,
         c.saturday,
         c.sunday
@@ -147,7 +172,7 @@ trip_times AS (
 wd_gaps AS (
     SELECT agency_id, route_id, direction_id,
         LEAD(start_secs) OVER (
-            PARTITION BY agency_id, route_id, direction_id
+            PARTITION BY agency_id, route_id, direction_id, service_id
             ORDER BY start_secs
         ) - start_secs AS gap_secs
     FROM trip_times
@@ -156,7 +181,7 @@ wd_gaps AS (
 sat_gaps AS (
     SELECT agency_id, route_id, direction_id,
         LEAD(start_secs) OVER (
-            PARTITION BY agency_id, route_id, direction_id
+            PARTITION BY agency_id, route_id, direction_id, service_id
             ORDER BY start_secs
         ) - start_secs AS gap_secs
     FROM trip_times
@@ -165,7 +190,7 @@ sat_gaps AS (
 sun_gaps AS (
     SELECT agency_id, route_id, direction_id,
         LEAD(start_secs) OVER (
-            PARTITION BY agency_id, route_id, direction_id
+            PARTITION BY agency_id, route_id, direction_id, service_id
             ORDER BY start_secs
         ) - start_secs AS gap_secs
     FROM trip_times
@@ -201,7 +226,8 @@ all_gaps AS (
 ),
 gap_summary AS (
     SELECT agency_id, route_id,
-        MIN(gap_secs::double precision) / 60.0 AS min_headway_mins,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS top_decile_headway_mins,
         MAX(gap_secs::double precision) / 60.0 AS max_headway_mins
     FROM all_gaps
     WHERE gap_secs > 0
@@ -232,7 +258,7 @@ SELECT
     wd.weekday_headway_mins,
     sat.saturday_headway_mins,
     sun.sunday_headway_mins,
-    gs.min_headway_mins,
+    gs.top_decile_headway_mins,
     gs.max_headway_mins,
     ss.service_start_secs,
     ss.service_end_secs,
@@ -328,11 +354,18 @@ mod tests {
             weekday_headway_mins: wd,
             saturday_headway_mins: sat,
             sunday_headway_mins: sun,
-            min_headway_mins: Some(5.0),
-            max_headway_mins: Some(30.0),
-            service_start_secs: Some(6 * 3600),
-            service_end_secs: Some(23 * 3600 + 30 * 60),
-            trip_count: 42,
+            weekday_top_decile_mins: wd.map(|_| 5.0),
+            weekday_max_headway_mins: wd.map(|_| 30.0),
+            weekday_service_start_secs: wd.map(|_| 6 * 3600),
+            weekday_service_end_secs: wd.map(|_| 23 * 3600 + 30 * 60),
+            saturday_top_decile_mins: sat.map(|_| 10.0),
+            saturday_max_headway_mins: sat.map(|_| 40.0),
+            saturday_service_start_secs: sat.map(|_| 8 * 3600),
+            saturday_service_end_secs: sat.map(|_| 22 * 3600),
+            sunday_top_decile_mins: sun.map(|_| 15.0),
+            sunday_max_headway_mins: sun.map(|_| 50.0),
+            sunday_service_start_secs: sun.map(|_| 9 * 3600),
+            sunday_service_end_secs: sun.map(|_| 21 * 3600),
         }
     }
 
@@ -361,22 +394,39 @@ mod tests {
     }
 
     #[test]
-    fn min_max_headway_display_formats_range() {
-        let row = make_row(Some(8.0), Some(15.0), Some(20.0));
-        assert_eq!(row.min_headway_display(), "5.0 min");
-        assert_eq!(row.max_headway_display(), "30.0 min");
+    fn service_span_none_none_returns_dash() {
+        assert_eq!(RouteHeadwayRow::service_span(None, None), "—");
     }
 
     #[test]
-    fn service_span_display_formats_times() {
-        let row = make_row(Some(8.0), Some(15.0), Some(20.0));
-        assert_eq!(row.service_span_display(), "06:00-23:30");
+    fn weekday_service_span_display_formats_correctly() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_service_span_display(), "06:00-23:30");
     }
 
     #[test]
-    fn service_span_display_wraps_after_midnight() {
-        let mut row = make_row(Some(8.0), Some(15.0), Some(20.0));
-        row.service_end_secs = Some(25 * 3600 + 15 * 60);
-        assert_eq!(row.service_span_display(), "06:00-25:15");
+    fn weekday_service_span_display_wraps_after_midnight() {
+        let mut row = make_row(Some(8.0), None, None);
+        row.weekday_service_end_secs = Some(25 * 3600 + 15 * 60);
+        assert_eq!(row.weekday_service_span_display(), "06:00-25:15");
+    }
+
+    #[test]
+    fn saturday_service_span_display_formats_correctly() {
+        let row = make_row(None, Some(15.0), None);
+        assert_eq!(row.saturday_service_span_display(), "08:00-22:00");
+    }
+
+    #[test]
+    fn sunday_service_span_display_formats_correctly() {
+        let row = make_row(None, None, Some(20.0));
+        assert_eq!(row.sunday_service_span_display(), "09:00-21:00");
+    }
+
+    #[test]
+    fn weekday_top_decile_and_max_display() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_top_decile_display(), "5.0 min");
+        assert_eq!(row.weekday_max_headway_display(), "30.0 min");
     }
 }

--- a/crates/core/src/frequency/mod.rs
+++ b/crates/core/src/frequency/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use crate::db::Database;
-use crate::ids::{AgencyId, DirectionId, RouteId};
+use crate::ids::{AgencyId, RouteId};
 
 #[derive(Debug, sqlx::FromRow, Serialize)]
 pub struct RouteHeadwayRow {
@@ -10,7 +10,6 @@ pub struct RouteHeadwayRow {
     pub route_id: RouteId,
     pub short_name: String,
     pub long_name: String,
-    pub direction_id: DirectionId,
     pub weekday_headway_mins: Option<f64>,
     pub saturday_headway_mins: Option<f64>,
     pub sunday_headway_mins: Option<f64>,
@@ -97,14 +96,6 @@ impl RouteHeadwayRow {
         Self::headway_badge_variant(self.max_headway_mins)
     }
 
-    pub fn direction_label(&self) -> &'static str {
-        match self.direction_id.as_i64() {
-            0 => "Outbound",
-            1 => "Inbound",
-            _ => "—",
-        }
-    }
-
     pub fn primary_headway_min(&self) -> Option<f64> {
         self.weekday_headway_mins
             .or(self.saturday_headway_mins)
@@ -181,25 +172,25 @@ sun_gaps AS (
     WHERE is_sunday
 ),
 wd_headways AS (
-    SELECT agency_id, route_id, direction_id,
+    SELECT agency_id, route_id,
         AVG(gap_secs::double precision) / 60.0 AS weekday_headway_mins
     FROM wd_gaps
     WHERE gap_secs > 0
-    GROUP BY agency_id, route_id, direction_id
+    GROUP BY agency_id, route_id
 ),
 sat_headways AS (
-    SELECT agency_id, route_id, direction_id,
+    SELECT agency_id, route_id,
         AVG(gap_secs::double precision) / 60.0 AS saturday_headway_mins
     FROM sat_gaps
     WHERE gap_secs > 0
-    GROUP BY agency_id, route_id, direction_id
+    GROUP BY agency_id, route_id
 ),
 sun_headways AS (
-    SELECT agency_id, route_id, direction_id,
+    SELECT agency_id, route_id,
         AVG(gap_secs::double precision) / 60.0 AS sunday_headway_mins
     FROM sun_gaps
     WHERE gap_secs > 0
-    GROUP BY agency_id, route_id, direction_id
+    GROUP BY agency_id, route_id
 ),
 all_gaps AS (
     SELECT * FROM wd_gaps
@@ -209,28 +200,27 @@ all_gaps AS (
     SELECT * FROM sun_gaps
 ),
 gap_summary AS (
-    SELECT agency_id, route_id, direction_id,
+    SELECT agency_id, route_id,
         MIN(gap_secs::double precision) / 60.0 AS min_headway_mins,
         MAX(gap_secs::double precision) / 60.0 AS max_headway_mins
     FROM all_gaps
     WHERE gap_secs > 0
-    GROUP BY agency_id, route_id, direction_id
+    GROUP BY agency_id, route_id
 ),
 service_summary AS (
-    SELECT agency_id, route_id, direction_id,
+    SELECT agency_id, route_id,
         MIN(start_secs) AS service_start_secs,
         MAX(end_secs) AS service_end_secs,
         COUNT(*) AS trip_count
     FROM trip_times
-    GROUP BY agency_id, route_id, direction_id
+    GROUP BY agency_id, route_id
 ),
 route_dirs AS (
     SELECT DISTINCT
         tt.agency_id,
         tt.route_id,
         r.short_name,
-        r.long_name,
-        tt.direction_id
+        r.long_name
     FROM trip_times tt
     JOIN routes r ON r.agency_id = tt.agency_id AND r.route_id = tt.route_id
 )
@@ -239,7 +229,6 @@ SELECT
     rd.route_id,
     rd.short_name,
     rd.long_name,
-    rd.direction_id,
     wd.weekday_headway_mins,
     sat.saturday_headway_mins,
     sun.sunday_headway_mins,
@@ -252,23 +241,18 @@ FROM route_dirs rd
 LEFT JOIN wd_headways wd
   ON wd.agency_id = rd.agency_id
  AND wd.route_id  = rd.route_id
- AND wd.direction_id = rd.direction_id
 LEFT JOIN sat_headways sat
   ON sat.agency_id = rd.agency_id
  AND sat.route_id  = rd.route_id
- AND sat.direction_id = rd.direction_id
 LEFT JOIN sun_headways sun
   ON sun.agency_id = rd.agency_id
  AND sun.route_id  = rd.route_id
- AND sun.direction_id = rd.direction_id
 LEFT JOIN gap_summary gs
   ON gs.agency_id = rd.agency_id
  AND gs.route_id  = rd.route_id
- AND gs.direction_id = rd.direction_id
 LEFT JOIN service_summary ss
   ON ss.agency_id = rd.agency_id
  AND ss.route_id  = rd.route_id
- AND ss.direction_id = rd.direction_id
 WHERE ($1::text IS NULL OR rd.agency_id = $1)
   AND (
       wd.weekday_headway_mins IS NOT NULL
@@ -284,8 +268,7 @@ ORDER BY
     ) ASC NULLS LAST,
     CASE WHEN rd.short_name ~ '^[0-9]+$'
          THEN rd.short_name::INTEGER ELSE NULL END NULLS LAST,
-    rd.short_name,
-    rd.direction_id";
+    rd.short_name";
 
     let rows = sqlx::query_as(sql)
         .bind(agency_filter.map(|a| a.as_str()))
@@ -342,7 +325,6 @@ mod tests {
             route_id: RouteId::from("r"),
             short_name: "1".to_string(),
             long_name: "Route 1".to_string(),
-            direction_id: DirectionId(0),
             weekday_headway_mins: wd,
             saturday_headway_mins: sat,
             sunday_headway_mins: sun,
@@ -352,19 +334,6 @@ mod tests {
             service_end_secs: Some(23 * 3600 + 30 * 60),
             trip_count: 42,
         }
-    }
-
-    #[test]
-    fn direction_label_outbound() {
-        let row = make_row(None, None, None);
-        assert_eq!(row.direction_label(), "Outbound"); // direction_id = 0 from make_row
-    }
-
-    #[test]
-    fn direction_label_inbound() {
-        let mut row = make_row(None, None, None);
-        row.direction_id = DirectionId(1);
-        assert_eq!(row.direction_label(), "Inbound");
     }
 
     #[test]

--- a/crates/core/src/frequency/mod.rs
+++ b/crates/core/src/frequency/mod.rs
@@ -217,28 +217,55 @@ sun_headways AS (
     WHERE gap_secs > 0
     GROUP BY agency_id, route_id
 ),
-all_gaps AS (
-    SELECT * FROM wd_gaps
-    UNION ALL
-    SELECT * FROM sat_gaps
-    UNION ALL
-    SELECT * FROM sun_gaps
-),
-gap_summary AS (
+wd_gap_summary AS (
     SELECT agency_id, route_id,
         PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
-            AS top_decile_headway_mins,
-        MAX(gap_secs::double precision) / 60.0 AS max_headway_mins
-    FROM all_gaps
+            AS weekday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS weekday_max_headway_mins
+    FROM wd_gaps
     WHERE gap_secs > 0
     GROUP BY agency_id, route_id
 ),
-service_summary AS (
+sat_gap_summary AS (
     SELECT agency_id, route_id,
-        MIN(start_secs) AS service_start_secs,
-        MAX(end_secs) AS service_end_secs,
-        COUNT(*) AS trip_count
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS saturday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS saturday_max_headway_mins
+    FROM sat_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sun_gap_summary AS (
+    SELECT agency_id, route_id,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS sunday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS sunday_max_headway_mins
+    FROM sun_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+wd_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS weekday_service_start_secs,
+        MAX(end_secs)   AS weekday_service_end_secs
     FROM trip_times
+    WHERE is_weekday
+    GROUP BY agency_id, route_id
+),
+sat_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS saturday_service_start_secs,
+        MAX(end_secs)   AS saturday_service_end_secs
+    FROM trip_times
+    WHERE is_saturday
+    GROUP BY agency_id, route_id
+),
+sun_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS sunday_service_start_secs,
+        MAX(end_secs)   AS sunday_service_end_secs
+    FROM trip_times
+    WHERE is_sunday
     GROUP BY agency_id, route_id
 ),
 route_dirs AS (
@@ -258,11 +285,18 @@ SELECT
     wd.weekday_headway_mins,
     sat.saturday_headway_mins,
     sun.sunday_headway_mins,
-    gs.top_decile_headway_mins,
-    gs.max_headway_mins,
-    ss.service_start_secs,
-    ss.service_end_secs,
-    ss.trip_count
+    wgs.weekday_top_decile_mins,
+    wgs.weekday_max_headway_mins,
+    ws.weekday_service_start_secs,
+    ws.weekday_service_end_secs,
+    sgs.saturday_top_decile_mins,
+    sgs.saturday_max_headway_mins,
+    ss_sat.saturday_service_start_secs,
+    ss_sat.saturday_service_end_secs,
+    sugs.sunday_top_decile_mins,
+    sugs.sunday_max_headway_mins,
+    ss_sun.sunday_service_start_secs,
+    ss_sun.sunday_service_end_secs
 FROM route_dirs rd
 LEFT JOIN wd_headways wd
   ON wd.agency_id = rd.agency_id
@@ -273,12 +307,24 @@ LEFT JOIN sat_headways sat
 LEFT JOIN sun_headways sun
   ON sun.agency_id = rd.agency_id
  AND sun.route_id  = rd.route_id
-LEFT JOIN gap_summary gs
-  ON gs.agency_id = rd.agency_id
- AND gs.route_id  = rd.route_id
-LEFT JOIN service_summary ss
-  ON ss.agency_id = rd.agency_id
- AND ss.route_id  = rd.route_id
+LEFT JOIN wd_gap_summary wgs
+  ON wgs.agency_id = rd.agency_id
+ AND wgs.route_id  = rd.route_id
+LEFT JOIN sat_gap_summary sgs
+  ON sgs.agency_id = rd.agency_id
+ AND sgs.route_id  = rd.route_id
+LEFT JOIN sun_gap_summary sugs
+  ON sugs.agency_id = rd.agency_id
+ AND sugs.route_id  = rd.route_id
+LEFT JOIN wd_service ws
+  ON ws.agency_id = rd.agency_id
+ AND ws.route_id  = rd.route_id
+LEFT JOIN sat_service ss_sat
+  ON ss_sat.agency_id = rd.agency_id
+ AND ss_sat.route_id  = rd.route_id
+LEFT JOIN sun_service ss_sun
+  ON ss_sun.agency_id = rd.agency_id
+ AND ss_sun.route_id  = rd.route_id
 WHERE ($1::text IS NULL OR rd.agency_id = $1)
   AND (
       wd.weekday_headway_mins IS NOT NULL

--- a/crates/core/src/frequency/mod.rs
+++ b/crates/core/src/frequency/mod.rs
@@ -72,11 +72,17 @@ impl RouteHeadwayRow {
     }
 
     pub fn weekday_service_span_display(&self) -> String {
-        Self::service_span(self.weekday_service_start_secs, self.weekday_service_end_secs)
+        Self::service_span(
+            self.weekday_service_start_secs,
+            self.weekday_service_end_secs,
+        )
     }
 
     pub fn saturday_service_span_display(&self) -> String {
-        Self::service_span(self.saturday_service_start_secs, self.saturday_service_end_secs)
+        Self::service_span(
+            self.saturday_service_start_secs,
+            self.saturday_service_end_secs,
+        )
     }
 
     pub fn sunday_service_span_display(&self) -> String {

--- a/crates/core/src/ids.rs
+++ b/crates/core/src/ids.rs
@@ -3,9 +3,16 @@ use std::{fmt, ops::Deref};
 macro_rules! string_id {
     ($name:ident) => {
         #[derive(
-            Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+            Debug,
+            Clone,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Hash,
             sqlx::Type,
-            serde::Serialize, serde::Deserialize,
+            serde::Serialize,
+            serde::Deserialize,
         )]
         #[sqlx(transparent)]
         #[serde(transparent)]
@@ -82,7 +89,19 @@ impl From<u32> for AgencyId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    sqlx::Type,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[sqlx(transparent)]
 #[serde(transparent)]
 pub struct DirectionId(pub i64);

--- a/crates/core/src/metrics/route_summary.rs
+++ b/crates/core/src/metrics/route_summary.rs
@@ -178,11 +178,15 @@ mod tests {
         let all = route_summary(&db, 30, None).await.unwrap();
         assert_eq!(all.len(), 2);
 
-        let stm = route_summary(&db, 30, Some(&AgencyId::from("stm"))).await.unwrap();
+        let stm = route_summary(&db, 30, Some(&AgencyId::from("stm")))
+            .await
+            .unwrap();
         assert_eq!(stm.len(), 1);
         assert_eq!(stm[0].agency_id, "stm");
 
-        let rtl = route_summary(&db, 30, Some(&AgencyId::from("rtl"))).await.unwrap();
+        let rtl = route_summary(&db, 30, Some(&AgencyId::from("rtl")))
+            .await
+            .unwrap();
         assert_eq!(rtl.len(), 1);
         assert_eq!(rtl[0].agency_id, "rtl");
     }

--- a/crates/core/src/metrics/trend.rs
+++ b/crates/core/src/metrics/trend.rs
@@ -138,7 +138,9 @@ mod tests {
     async fn route_trend_returns_none_for_unknown_route() {
         let td = test_utils::setup().await;
         let db = td.db;
-        let result = route_trend(&db, &AgencyId::from("0"), &RouteId::from("NONEXISTENT"), 30).await.unwrap();
+        let result = route_trend(&db, &AgencyId::from("0"), &RouteId::from("NONEXISTENT"), 30)
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
@@ -161,7 +163,10 @@ mod tests {
              VALUES ('0', 'R1', '2026-01-02', 68.0, 145.0, 44, 50, '2026-01-02T12:00:00Z')",
         ).execute(&db.pool).await.unwrap();
 
-        let trend = route_trend(&db, &AgencyId::from("0"), &RouteId::from("R1"), 3650).await.unwrap().unwrap();
+        let trend = route_trend(&db, &AgencyId::from("0"), &RouteId::from("R1"), 3650)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(trend.route_id, "R1");
         assert_eq!(trend.short_name, "45");
@@ -189,7 +194,10 @@ mod tests {
              VALUES ('0', 'R1', '2026-01-01', 0, 5.5, 45, '2026-01-01T12:00:00Z')",
         ).execute(&db.pool).await.unwrap();
 
-        let trend = route_trend(&db, &AgencyId::from("0"), &RouteId::from("R1"), 3650).await.unwrap().unwrap();
+        let trend = route_trend(&db, &AgencyId::from("0"), &RouteId::from("R1"), 3650)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(trend.days.len(), 1);
         assert!((trend.days[0].actual_speed_mps.unwrap() - 5.5).abs() < 0.01);

--- a/crates/core/src/speed/card.rs
+++ b/crates/core/src/speed/card.rs
@@ -212,22 +212,27 @@ pub fn filter_speed_cards(cards: Vec<RouteSpeedCard>, class: &str) -> Vec<RouteS
     let Some(target) = parse_class(class) else {
         return cards;
     };
-    cards.into_iter().filter(|c| c.classification == Some(target)).collect()
+    cards
+        .into_iter()
+        .filter(|c| c.classification == Some(target))
+        .collect()
 }
 
 pub fn sort_speed_cards(mut cards: Vec<RouteSpeedCard>, sort: &str) -> Vec<RouteSpeedCard> {
     match sort {
-        "scheduled" => cards.sort_by(
-            |a, b| match (a.avg_scheduled_speed_mps, b.avg_scheduled_speed_mps) {
-                (Some(x), Some(y)) => x
-                    .partial_cmp(&y)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then(a.short_name.cmp(&b.short_name)),
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => a.short_name.cmp(&b.short_name),
-            },
-        ),
+        "scheduled" => {
+            cards.sort_by(
+                |a, b| match (a.avg_scheduled_speed_mps, b.avg_scheduled_speed_mps) {
+                    (Some(x), Some(y)) => x
+                        .partial_cmp(&y)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then(a.short_name.cmp(&b.short_name)),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => a.short_name.cmp(&b.short_name),
+                },
+            )
+        }
         "actual" => cards.sort_by(
             |a, b| match (a.avg_actual_speed_mps, b.avg_actual_speed_mps) {
                 (Some(x), Some(y)) => x
@@ -967,7 +972,11 @@ mod tests {
         }
     }
 
-    fn make_card_with_speeds(short_name: &str, scheduled: f64, actual: Option<f64>) -> RouteSpeedCard {
+    fn make_card_with_speeds(
+        short_name: &str,
+        scheduled: f64,
+        actual: Option<f64>,
+    ) -> RouteSpeedCard {
         RouteSpeedCard {
             avg_scheduled_speed_mps: Some(scheduled),
             avg_actual_speed_mps: actual,
@@ -1007,8 +1016,14 @@ mod tests {
     #[test]
     fn filter_keeps_matching_class() {
         let cards = vec![
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
-            RouteSpeedCard { classification: Some(RouteClass::Rapid), ..make_card("R") },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Rapid),
+                ..make_card("R")
+            },
         ];
         let result = filter_speed_cards(cards, "rapid");
         assert_eq!(result.len(), 1);
@@ -1018,8 +1033,14 @@ mod tests {
     #[test]
     fn filter_empty_class_keeps_all() {
         let cards = vec![
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
-            RouteSpeedCard { classification: None, ..make_card("U") },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
+            RouteSpeedCard {
+                classification: None,
+                ..make_card("U")
+            },
         ];
         let result = filter_speed_cards(cards, "");
         assert_eq!(result.len(), 2);
@@ -1028,8 +1049,14 @@ mod tests {
     #[test]
     fn filter_hides_unclassified_when_class_given() {
         let cards = vec![
-            RouteSpeedCard { classification: None, ..make_card("U") },
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
+            RouteSpeedCard {
+                classification: None,
+                ..make_card("U")
+            },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
         ];
         let result = filter_speed_cards(cards, "local");
         assert_eq!(result.len(), 1);
@@ -1040,7 +1067,10 @@ mod tests {
 
     #[test]
     fn sort_scheduled_ascending() {
-        let cards = vec![make_card_with_speeds("B", 10.0, None), make_card_with_speeds("A", 5.0, None)];
+        let cards = vec![
+            make_card_with_speeds("B", 10.0, None),
+            make_card_with_speeds("A", 5.0, None),
+        ];
         let result = sort_speed_cards(cards, "scheduled");
         assert_eq!(result[0].short_name, "A");
         assert_eq!(result[1].short_name, "B");
@@ -1056,21 +1086,30 @@ mod tests {
 
     #[test]
     fn sort_scheduled_ties_broken_by_name() {
-        let cards = vec![make_card_with_speeds("Z", 5.0, None), make_card_with_speeds("A", 5.0, None)];
+        let cards = vec![
+            make_card_with_speeds("Z", 5.0, None),
+            make_card_with_speeds("A", 5.0, None),
+        ];
         let result = sort_speed_cards(cards, "scheduled");
         assert_eq!(result[0].short_name, "A");
     }
 
     #[test]
     fn sort_actual_ascending() {
-        let cards = vec![make_card_with_speeds("B", 10.0, Some(8.0)), make_card_with_speeds("A", 5.0, Some(3.0))];
+        let cards = vec![
+            make_card_with_speeds("B", 10.0, Some(8.0)),
+            make_card_with_speeds("A", 5.0, Some(3.0)),
+        ];
         let result = sort_speed_cards(cards, "actual");
         assert_eq!(result[0].short_name, "A");
     }
 
     #[test]
     fn sort_actual_none_last() {
-        let cards = vec![make_card_with_speeds("A", 5.0, None), make_card_with_speeds("B", 10.0, Some(3.0))];
+        let cards = vec![
+            make_card_with_speeds("A", 5.0, None),
+            make_card_with_speeds("B", 10.0, Some(3.0)),
+        ];
         let result = sort_speed_cards(cards, "actual");
         assert_eq!(result[0].short_name, "B");
     }
@@ -1078,8 +1117,14 @@ mod tests {
     #[test]
     fn sort_spacing_ascending() {
         let cards = vec![
-            RouteSpeedCard { avg_stop_spacing_m: Some(800.0), ..make_card("B") },
-            RouteSpeedCard { avg_stop_spacing_m: Some(300.0), ..make_card("A") },
+            RouteSpeedCard {
+                avg_stop_spacing_m: Some(800.0),
+                ..make_card("B")
+            },
+            RouteSpeedCard {
+                avg_stop_spacing_m: Some(300.0),
+                ..make_card("A")
+            },
         ];
         let result = sort_speed_cards(cards, "spacing");
         assert_eq!(result[0].short_name, "A");
@@ -1097,9 +1142,18 @@ mod tests {
     #[test]
     fn assign_indices_sets_sequential_idx_from_zero() {
         let cards = vec![
-            RouteSpeedCard { idx: 99, ..make_card("A") },
-            RouteSpeedCard { idx: 99, ..make_card("B") },
-            RouteSpeedCard { idx: 99, ..make_card("C") },
+            RouteSpeedCard {
+                idx: 99,
+                ..make_card("A")
+            },
+            RouteSpeedCard {
+                idx: 99,
+                ..make_card("B")
+            },
+            RouteSpeedCard {
+                idx: 99,
+                ..make_card("C")
+            },
         ];
         let result = assign_indices(cards);
         assert_eq!(result[0].idx, 0);

--- a/crates/core/src/speed/detail.rs
+++ b/crates/core/src/speed/detail.rs
@@ -175,9 +175,18 @@ mod tests {
         let dirs = build_detail_directions(spacings, trends);
         // make_trend sets weekday: [("2026-01-06", 8.0 mps, Some(9.0 mps))]
         // 8.0 m/s → 28.8 km/h, 9.0 m/s → 32.4 km/h
-        assert!(dirs[0].weekday_json.contains("2026-01-06"), "date must appear in JSON");
-        assert!(dirs[0].weekday_json.contains("28.8"), "actual km/h must appear");
-        assert!(dirs[0].weekday_json.contains("32.4"), "scheduled km/h must appear");
+        assert!(
+            dirs[0].weekday_json.contains("2026-01-06"),
+            "date must appear in JSON"
+        );
+        assert!(
+            dirs[0].weekday_json.contains("28.8"),
+            "actual km/h must appear"
+        );
+        assert!(
+            dirs[0].weekday_json.contains("32.4"),
+            "scheduled km/h must appear"
+        );
     }
 
     #[test]
@@ -204,11 +213,18 @@ mod tests {
     fn avg_spacing_display_under_1km_shows_metres() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 342.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_display(), "342 m");
     }
@@ -217,11 +233,18 @@ mod tests {
     fn avg_spacing_display_at_or_over_1km_shows_km() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 1200.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_display(), "1.2 km");
     }
@@ -230,11 +253,18 @@ mod tests {
     fn avg_spacing_status_class_below_local_range_min_is_slow() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 200.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_status_class(), "slow");
     }
@@ -243,11 +273,18 @@ mod tests {
     fn avg_spacing_status_class_in_range_is_empty() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 400.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_status_class(), "");
     }
@@ -256,11 +293,18 @@ mod tests {
     fn avg_spacing_status_class_exactly_300_is_in_range() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 300.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_status_class(), "");
     }
@@ -269,11 +313,18 @@ mod tests {
     fn avg_spacing_status_class_exactly_5000_is_in_range() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 5000.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_status_class(), "");
     }
@@ -282,11 +333,18 @@ mod tests {
     fn avg_spacing_status_class_above_express_max_is_outlier() {
         let d = RouteSpeedDetailDirection {
             avg_spacing_m: 6000.0,
-            variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), is_primary: false, trip_count: 0,
-            spacings: vec![], weekday_chart_id: String::new(),
-            saturday_chart_id: String::new(), sunday_chart_id: String::new(),
-            weekday_json: String::new(), saturday_json: String::new(), sunday_json: String::new(),
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            is_primary: false,
+            trip_count: 0,
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.avg_spacing_status_class(), "outlier");
     }
@@ -294,12 +352,19 @@ mod tests {
     #[test]
     fn direction_badge_label_primary_includes_primary_text() {
         let d = RouteSpeedDetailDirection {
-            is_primary: true, trip_count: 42,
-            avg_spacing_m: 0.0, variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), spacings: vec![],
-            weekday_chart_id: String::new(), saturday_chart_id: String::new(),
-            sunday_chart_id: String::new(), weekday_json: String::new(),
-            saturday_json: String::new(), sunday_json: String::new(),
+            is_primary: true,
+            trip_count: 42,
+            avg_spacing_m: 0.0,
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.direction_badge_label(), "Primary \u{00B7} 42 trips");
     }
@@ -307,12 +372,19 @@ mod tests {
     #[test]
     fn direction_badge_label_non_primary_shows_trip_count_only() {
         let d = RouteSpeedDetailDirection {
-            is_primary: false, trip_count: 7,
-            avg_spacing_m: 0.0, variant_id: VariantId::from(""), direction_name: String::new(),
-            first_stop_name: String::new(), spacings: vec![],
-            weekday_chart_id: String::new(), saturday_chart_id: String::new(),
-            sunday_chart_id: String::new(), weekday_json: String::new(),
-            saturday_json: String::new(), sunday_json: String::new(),
+            is_primary: false,
+            trip_count: 7,
+            avg_spacing_m: 0.0,
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
         };
         assert_eq!(d.direction_badge_label(), "7 trips");
     }

--- a/crates/core/src/speed/mod.rs
+++ b/crates/core/src/speed/mod.rs
@@ -1813,11 +1813,15 @@ mod tests {
         let all = route_speed_summary(&db, None).await.unwrap();
         assert_eq!(all.len(), 2);
 
-        let stm = route_speed_summary(&db, Some(&AgencyId::from("stm"))).await.unwrap();
+        let stm = route_speed_summary(&db, Some(&AgencyId::from("stm")))
+            .await
+            .unwrap();
         assert_eq!(stm.len(), 1);
         assert_eq!(stm[0].agency_id, "stm");
 
-        let rtl = route_speed_summary(&db, Some(&AgencyId::from("rtl"))).await.unwrap();
+        let rtl = route_speed_summary(&db, Some(&AgencyId::from("rtl")))
+            .await
+            .unwrap();
         assert_eq!(rtl.len(), 1);
         assert_eq!(rtl[0].agency_id, "rtl");
     }
@@ -2110,7 +2114,9 @@ mod tests {
         .await
         .unwrap();
 
-        let rows = route_speed_by_day_type(&db, Some(&AgencyId::from("0"))).await.unwrap();
+        let rows = route_speed_by_day_type(&db, Some(&AgencyId::from("0")))
+            .await
+            .unwrap();
 
         assert_eq!(rows.len(), 1);
         let r = &rows[0];
@@ -2187,8 +2193,8 @@ mod tests {
         // from calendar_dates.txt (the STM case — no calendar.txt).
         // 2026-01-05 = Monday → SVC_WD weekday; 2026-01-10 = Saturday; 2026-01-11 = Sunday
         for (svc, mon, tue, wed, thu, fri, sat, sun) in [
-            ("SVC_WD",  true,  true,  true,  true,  true,  false, false),
-            ("SVC_SAT", false, false, false, false, false, true,  false),
+            ("SVC_WD", true, true, true, true, true, false, false),
+            ("SVC_SAT", false, false, false, false, false, true, false),
             ("SVC_SUN", false, false, false, false, false, false, true),
         ] {
             sqlx::query(
@@ -3197,7 +3203,9 @@ mod tests {
             .await
             .unwrap();
 
-        let directions = route_stop_spacings(db, &AgencyId::from("0"), &RouteId::from("R1")).await.unwrap();
+        let directions = route_stop_spacings(db, &AgencyId::from("0"), &RouteId::from("R1"))
+            .await
+            .unwrap();
 
         assert_eq!(directions.len(), 1, "one variant expected");
         let dir = &directions[0];
@@ -3283,7 +3291,9 @@ mod tests {
             .await
             .unwrap();
 
-        let directions = route_stop_spacings(db, &AgencyId::from("0"), &RouteId::from("R1")).await.unwrap();
+        let directions = route_stop_spacings(db, &AgencyId::from("0"), &RouteId::from("R1"))
+            .await
+            .unwrap();
 
         assert_eq!(directions.len(), 2, "two variants expected");
         // VAR1 first (trip_count=10 > 3)
@@ -3303,9 +3313,10 @@ mod tests {
     #[tokio::test]
     async fn route_stop_spacings_returns_empty_for_unknown_route() {
         let td = test_utils::setup().await;
-        let result = route_stop_spacings(&td.db, &AgencyId::from("0"), &RouteId::from("NONEXISTENT"))
-            .await
-            .unwrap();
+        let result =
+            route_stop_spacings(&td.db, &AgencyId::from("0"), &RouteId::from("NONEXISTENT"))
+                .await
+                .unwrap();
         assert!(result.is_empty());
     }
 
@@ -3361,9 +3372,10 @@ mod tests {
             .unwrap();
         }
 
-        let trends = route_speed_trend_by_direction(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
-            .await
-            .unwrap();
+        let trends =
+            route_speed_trend_by_direction(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
+                .await
+                .unwrap();
         assert_eq!(trends.len(), 2, "two directions");
 
         let dir0 = trends.iter().find(|t| t.direction_id == 0).unwrap();
@@ -3385,9 +3397,10 @@ mod tests {
     #[tokio::test]
     async fn route_speed_trend_by_direction_returns_empty_when_no_data() {
         let td = test_utils::setup().await;
-        let result = route_speed_trend_by_direction(&td.db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
-            .await
-            .unwrap();
+        let result =
+            route_speed_trend_by_direction(&td.db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
+                .await
+                .unwrap();
         assert!(result.is_empty());
     }
 
@@ -3414,9 +3427,10 @@ mod tests {
         .await
         .unwrap();
 
-        let trends = route_speed_trend_by_direction(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
-            .await
-            .unwrap();
+        let trends =
+            route_speed_trend_by_direction(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
+                .await
+                .unwrap();
 
         // Actual data must appear even without a scheduled speed row.
         assert_eq!(trends.len(), 1, "one direction");
@@ -3541,9 +3555,10 @@ mod tests {
             .unwrap();
         }
 
-        let trends = route_speed_trend_by_variant(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
-            .await
-            .unwrap();
+        let trends =
+            route_speed_trend_by_variant(db, &AgencyId::from("0"), &RouteId::from("R1"), 28)
+                .await
+                .unwrap();
 
         assert_eq!(trends.len(), 2, "two variants expected");
         assert_eq!(trends[0].variant_id, "VAR1");

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -7,17 +7,16 @@ use axum::{
 use serde::Deserialize;
 use serde_json;
 
-use mobilispect_core::frequency::{RouteHeadwayRow, route_headways};
-use mobilispect_core::metrics::{RouteSummary, RouteTrend, route_summary, route_trend};
-use mobilispect_core::ids::{AgencyId, RouteId};
-use mobilispect_core::speed::{
-    RouteClass, RouteSpeedCard, RouteSpeedDetailDirection, RouteSpeedSummary,
-    assign_indices, build_detail_directions, build_speed_cards, classify_by_spacing,
-    fetch_route_info, filter_speed_cards, route_speed_by_day_type,
-    route_speed_summary, route_speed_trend_by_variant, route_stop_spacings, sort_speed_cards,
-};
 use crate::web::AppState;
-
+use mobilispect_core::frequency::{RouteHeadwayRow, route_headways};
+use mobilispect_core::ids::{AgencyId, RouteId};
+use mobilispect_core::metrics::{RouteSummary, RouteTrend, route_summary, route_trend};
+use mobilispect_core::speed::{
+    RouteClass, RouteSpeedCard, RouteSpeedDetailDirection, RouteSpeedSummary, assign_indices,
+    build_detail_directions, build_speed_cards, classify_by_spacing, fetch_route_info,
+    filter_speed_cards, route_speed_by_day_type, route_speed_summary, route_speed_trend_by_variant,
+    route_stop_spacings, sort_speed_cards,
+};
 
 #[derive(Template)]
 #[template(path = "route_speed_detail.html")]
@@ -29,7 +28,6 @@ struct RouteSpeedDetailTemplate {
     directions: Vec<RouteSpeedDetailDirection>,
     classification: Option<RouteClass>,
 }
-
 
 pub async fn route_speed_detail(
     State(state): State<AppState>,
@@ -108,7 +106,9 @@ pub async fn route_speed_detail(
     match tmpl.render() {
         Ok(html) => Html(html).into_response(),
         Err(e) => {
-            tracing::error!("Template render error for route_speed_detail {agency_id}/{route_id}: {e}");
+            tracing::error!(
+                "Template render error for route_speed_detail {agency_id}/{route_id}: {e}"
+            );
             (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 Html("<h1>Internal Server Error</h1>".to_string()),
@@ -129,7 +129,6 @@ pub struct SpeedParams {
     sort: Option<String>,
     class: Option<String>,
 }
-
 
 #[derive(Deserialize)]
 pub struct ApiRoutesParams {
@@ -199,7 +198,9 @@ pub async fn route_detail(
             let trend_json = match serde_json::to_string(&trend.days) {
                 Ok(json) => json,
                 Err(e) => {
-                    tracing::error!("Failed to serialize trend data for {agency_id}/{route_id}: {e}");
+                    tracing::error!(
+                        "Failed to serialize trend data for {agency_id}/{route_id}: {e}"
+                    );
                     return (
                         axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                         Html("<h1>Internal Server Error</h1>".to_string()),
@@ -216,7 +217,9 @@ pub async fn route_detail(
             match tmpl.render() {
                 Ok(html) => Html(html).into_response(),
                 Err(e) => {
-                    tracing::error!("Template render error for route_detail {agency_id}/{route_id}: {e}");
+                    tracing::error!(
+                        "Template render error for route_detail {agency_id}/{route_id}: {e}"
+                    );
                     (
                         axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                         Html("<h1>Internal Server Error</h1>".to_string()),
@@ -240,7 +243,6 @@ pub async fn route_detail(
         }
     }
 }
-
 
 pub async fn speed_page(
     State(state): State<AppState>,
@@ -447,15 +449,14 @@ pub async fn frequency_page(
     }
 }
 
-
 #[cfg(test)]
 mod e2e_tests {
     use super::*;
-    use mobilispect_core::config::{AgencyConfig, Config, RegionConfig};
-    use mobilispect_core::db::test_utils;
     use crate::web::build_router;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use mobilispect_core::config::{AgencyConfig, Config, RegionConfig};
+    use mobilispect_core::db::test_utils;
     use tower::ServiceExt;
 
     fn test_config() -> Config {
@@ -951,7 +952,7 @@ mod e2e_tests {
     }
 
     #[tokio::test]
-    async fn frequency_page_returns_full_html() {
+    async fn schedule_page_returns_full_html() {
         let td = test_utils::setup().await;
         let state = AppState {
             db: td.db,
@@ -979,8 +980,8 @@ mod e2e_tests {
             "full page response must contain an <html> element"
         );
         assert!(
-            html.contains("Route Frequency"),
-            "full page response must contain the page title text"
+            html.contains("Route Schedule"),
+            "full page response must contain the renamed page title text"
         );
         assert!(
             html.contains(r#"id="freq-content""#),
@@ -989,7 +990,7 @@ mod e2e_tests {
     }
 
     #[tokio::test]
-    async fn frequency_page_with_hx_request_returns_fragment() {
+    async fn schedule_page_with_hx_request_returns_fragment() {
         let td = test_utils::setup().await;
         let state = AppState {
             db: td.db,
@@ -1025,5 +1026,72 @@ mod e2e_tests {
             !html.contains("<html"),
             "fragment must not contain an <html> element"
         );
+    }
+
+    #[tokio::test]
+    async fn schedule_page_renders_route_schedule_cards() {
+        let td = test_utils::setup().await;
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        for (trip_id, dep_time, arr_time) in [
+            ("T1", "06:00:00", "06:30:00"),
+            ("T2", "06:10:00", "06:40:00"),
+            ("T3", "06:30:00", "07:00:00"),
+        ] {
+            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', 0, 'Downtown')")
+                .bind(trip_id)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+                .bind(trip_id)
+                .bind(dep_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+                .bind(trip_id)
+                .bind(arr_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+        }
+
+        let state = AppState {
+            db: td.db,
+            config: test_config(),
+        };
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/frequency")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(html.contains("schedule-card"));
+        assert!(html.contains("Min headway"));
+        assert!(html.contains("Max headway"));
+        assert!(html.contains("Service span"));
+        assert!(html.contains("06:00-07:00"));
+        assert!(html.contains("10.0 min"));
+        assert!(html.contains("20.0 min"));
     }
 }

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -1310,4 +1310,80 @@ mod e2e_tests {
         assert!(!html.contains("Outbound"));
         assert!(!html.contains("Inbound"));
     }
+
+    #[tokio::test]
+    async fn schedule_page_renders_saturday_column_when_saturday_service_exists() {
+        let td = test_utils::setup().await;
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('0', 'SAT', false, false, false, false, false, true, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+
+        for (trip_id, service_id, dep_time, arr_time) in [
+            ("T1", "WD", "06:00:00", "06:30:00"),
+            ("T2", "WD", "06:10:00", "06:40:00"),
+            ("T3", "SAT", "09:00:00", "09:30:00"),
+            ("T4", "SAT", "09:20:00", "09:50:00"),
+        ] {
+            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', $2, 0, 'Downtown')")
+                .bind(trip_id)
+                .bind(service_id)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+                .bind(trip_id)
+                .bind(dep_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+                .bind(trip_id)
+                .bind(arr_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+        }
+
+        let state = AppState {
+            db: td.db,
+            config: test_config(),
+        };
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/schedule")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(html.contains("Weekday"), "weekday column should render");
+        assert!(html.contains("Saturday"), "saturday column should render");
+        assert!(!html.contains("Sunday"), "sunday column should not render");
+        assert!(
+            html.contains("09:00-09:50"),
+            "saturday service span should be 09:00-09:50"
+        );
+    }
 }

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -1094,4 +1094,69 @@ mod e2e_tests {
         assert!(html.contains("10.0 min"));
         assert!(html.contains("20.0 min"));
     }
+
+    #[tokio::test]
+    async fn schedule_page_combines_directions_into_one_route_card() {
+        let td = test_utils::setup().await;
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        for (direction_id, trip_id, dep_time, arr_time) in [
+            (0, "T1", "06:00:00", "06:30:00"),
+            (0, "T2", "06:10:00", "06:40:00"),
+            (1, "T3", "06:05:00", "06:35:00"),
+            (1, "T4", "06:15:00", "06:45:00"),
+        ] {
+            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', $2, 'Downtown')")
+                .bind(trip_id)
+                .bind(direction_id)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+                .bind(trip_id)
+                .bind(dep_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+                .bind(trip_id)
+                .bind(arr_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+        }
+
+        let state = AppState {
+            db: td.db,
+            config: test_config(),
+        };
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/schedule")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert_eq!(html.matches("card schedule-card").count(), 1);
+        assert!(!html.contains("Outbound"));
+        assert!(!html.contains("Inbound"));
+    }
 }

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -1087,12 +1087,163 @@ mod e2e_tests {
             .unwrap();
         let html = String::from_utf8(bytes.to_vec()).unwrap();
         assert!(html.contains("schedule-card"));
-        assert!(html.contains("Min headway"));
-        assert!(html.contains("Max headway"));
-        assert!(html.contains("Service span"));
+        assert!(html.contains("Top 10%"));
+        assert!(html.contains("Max"));
+        assert!(html.contains("Span"));
         assert!(html.contains("06:00-07:00"));
-        assert!(html.contains("10.0 min"));
+        assert!(html.contains("11.0 min"));
         assert!(html.contains("20.0 min"));
+    }
+
+    #[tokio::test]
+    async fn schedule_page_uses_top_decile_headway_instead_of_minimum() {
+        let td = test_utils::setup().await;
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+
+        let mut departure_secs = 6 * 3600;
+        for i in 0..21 {
+            let trip_id = format!("T{i}");
+            let dep_time = format!(
+                "{:02}:{:02}:00",
+                departure_secs / 3600,
+                (departure_secs % 3600) / 60
+            );
+            let arr_secs = departure_secs + 30 * 60;
+            let arr_time = format!("{:02}:{:02}:00", arr_secs / 3600, (arr_secs % 3600) / 60);
+            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', 0, 'Downtown')")
+                .bind(&trip_id)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+                .bind(&trip_id)
+                .bind(&dep_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+                .bind(&trip_id)
+                .bind(&arr_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+
+            departure_secs += if i == 0 { 60 } else { 10 * 60 };
+        }
+
+        let state = AppState {
+            db: td.db,
+            config: test_config(),
+        };
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/schedule")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(html.contains("Top 10%"));
+        assert!(
+            html.contains("10.0 min"),
+            "top decile should ignore the single 1-minute minimum gap"
+        );
+        assert!(
+            !html.contains("1.0 min"),
+            "raw minimum gap should not be displayed as the best headway"
+        );
+    }
+
+    #[tokio::test]
+    async fn schedule_page_computes_headways_within_each_service_id() {
+        let td = test_utils::setup().await;
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        for service_id in ["WD1", "WD2"] {
+            sqlx::query(
+                "INSERT INTO calendar VALUES ('0', $1, true, true, true, true, true, false, false)",
+            )
+            .bind(service_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        }
+
+        for (trip_id, service_id, dep_time, arr_time) in [
+            ("T1", "WD1", "06:00:00", "06:30:00"),
+            ("T2", "WD1", "06:10:00", "06:40:00"),
+            ("T3", "WD1", "06:20:00", "06:50:00"),
+            ("T4", "WD2", "06:01:00", "06:31:00"),
+            ("T5", "WD2", "06:11:00", "06:41:00"),
+            ("T6", "WD2", "06:21:00", "06:51:00"),
+        ] {
+            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', $2, 0, 'Downtown')")
+                .bind(trip_id)
+                .bind(service_id)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+                .bind(trip_id)
+                .bind(dep_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+                .bind(trip_id)
+                .bind(arr_time)
+                .execute(&td.db.pool)
+                .await
+                .unwrap();
+        }
+
+        let state = AppState {
+            db: td.db,
+            config: test_config(),
+        };
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/schedule")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(html.contains("Top 10%"));
+        assert!(
+            html.contains("10.0 min"),
+            "overlapping service calendars should not create 1-minute headways"
+        );
+        assert!(!html.contains("1.0 min"));
     }
 
     #[tokio::test]

--- a/crates/server/src/web/mod.rs
+++ b/crates/server/src/web/mod.rs
@@ -18,6 +18,7 @@ pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/", get(handlers::speed_page))
         .route("/speed", get(handlers::speed_page))
+        .route("/schedule", get(handlers::frequency_page))
         .route("/frequency", get(handlers::frequency_page))
         // /speed route registered BEFORE bare :route_id to avoid shadowing
         .route(

--- a/crates/server/templates/base.html
+++ b/crates/server/templates/base.html
@@ -454,7 +454,7 @@
         </a>
         <nav>
             <a href="/" class="{% block nav_speed %}{% endblock %}">Speeds</a>
-            <a href="/frequency" class="{% block nav_frequency %}{% endblock %}">Frequency</a>
+            <a href="/schedule" class="{% block nav_frequency %}{% endblock %}">Schedule</a>
             <button id="theme-toggle" type="button" aria-label="Toggle colour scheme" onclick="toggleTheme()"
               style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:rgba(255,255,255,0.7);border-radius:6px;padding:4px 10px;cursor:pointer;font-family:'Fira Code',monospace;font-size:0.68rem;letter-spacing:0.05em;display:flex;align-items:center;gap:6px;">
               <span id="theme-icon">☀️</span><span id="theme-label">LIGHT</span>

--- a/crates/server/templates/frequency.html
+++ b/crates/server/templates/frequency.html
@@ -74,7 +74,7 @@
   padding-top: 0.75rem;
 }
 .day-col {
-  background: var(--bg-subtle, #F4F4EF);
+  background: var(--surface-muted);
   border-radius: 8px;
   padding: 8px 6px;
   text-align: center;

--- a/crates/server/templates/frequency.html
+++ b/crates/server/templates/frequency.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Mobilispect — Route Frequency{% endblock %}
+{% block title %}Mobilispect — Route Schedule{% endblock %}
 {% block region_name %}{{ region_name }}{% endblock %}
 {% block nav_frequency %}active{% endblock %}
 
@@ -38,6 +38,62 @@
 @keyframes freq-loading-spin {
   to { transform: rotate(360deg); }
 }
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 0.75rem;
+}
+.schedule-card {
+  padding: 1rem 1.25rem;
+}
+.schedule-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.schedule-card__name {
+  margin-top: 0.15rem;
+  color: var(--ink-500);
+  font-size: 0.82rem;
+}
+.schedule-card__direction {
+  color: var(--ink-500);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.schedule-card__stats {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  border-top: 1px solid var(--line-soft);
+  padding-top: 0.75rem;
+}
+.schedule-card__badges {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.schedule-card__badges .badge {
+  gap: 0.35rem;
+}
+.schedule-card__badge-label {
+  color: currentColor;
+  opacity: 0.72;
+}
+@media (max-width: 720px) {
+  .schedule-grid {
+    grid-template-columns: 1fr;
+  }
+  .schedule-card__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 </style>
 {% endblock %}
 
@@ -45,15 +101,15 @@
 <div class="container">
   <div class="page-header">
     <div>
-      <h1 class="page-title">Route Frequency</h1>
-      <p class="page-subtitle">Routes ranked by average headway — most frequent first</p>
+      <h1 class="page-title">Route Schedule</h1>
+      <p class="page-subtitle">Routes ranked by scheduled headway, with service span and day-type patterns</p>
     </div>
   </div>
   <span id="freq-loading"
         class="freq-loading htmx-indicator"
         role="status"
         aria-live="polite"
-        aria-atomic="true">Loading route frequency</span>
+        aria-atomic="true">Loading route schedule</span>
   {% include "frequency_content.html" %}
 </div>
 {% endblock %}

--- a/crates/server/templates/frequency.html
+++ b/crates/server/templates/frequency.html
@@ -65,33 +65,52 @@
   letter-spacing: 0.04em;
   white-space: nowrap;
 }
-.schedule-card__stats {
+.schedule-card__days {
   margin-top: 0.75rem;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 6px;
   border-top: 1px solid var(--line-soft);
   padding-top: 0.75rem;
 }
-.schedule-card__badges {
-  margin-top: 0.75rem;
+.day-col {
+  background: var(--bg-subtle, #F4F4EF);
+  border-radius: 8px;
+  padding: 8px 6px;
+  text-align: center;
+}
+.day-col .spacing-stat-num {
+  font-size: 1.3rem;
+  margin-bottom: 4px;
+}
+.day-col__hdr {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 4px;
+}
+.day-col__stat {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 3px;
+  gap: 4px;
+  font-size: 0.72rem;
+  color: var(--ink-500);
 }
-.schedule-card__badges .badge {
-  gap: 0.35rem;
-}
-.schedule-card__badge-label {
-  color: currentColor;
-  opacity: 0.72;
+.day-col__lbl {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-400);
+  white-space: nowrap;
 }
 @media (max-width: 720px) {
   .schedule-grid {
     grid-template-columns: 1fr;
-  }
-  .schedule-card__stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 </style>

--- a/crates/server/templates/frequency_content.html
+++ b/crates/server/templates/frequency_content.html
@@ -2,15 +2,15 @@
 <div id="freq-content" hx-indicator="#freq-loading">
   <div class="control-row" style="margin-bottom:1.5rem;">
     <span class="control-label">Agency:</span>
-    <a href="/frequency"
-       hx-get="/frequency"
+    <a href="/schedule"
+       hx-get="/schedule"
        hx-target="#freq-content"
        hx-swap="outerHTML"
        hx-push-url="true"
        class="{% if active_agency.is_empty() %}active{% endif %}">All</a>
     {% for (slug, name) in &agencies %}
-    <a href="/frequency?agency={{ slug }}"
-       hx-get="/frequency?agency={{ slug }}"
+    <a href="/schedule?agency={{ slug }}"
+       hx-get="/schedule?agency={{ slug }}"
        hx-target="#freq-content"
        hx-swap="outerHTML"
        hx-push-url="true"
@@ -19,39 +19,45 @@
   </div>
 
   {% if rows.is_empty() %}
-  <div class="empty-state">No frequency data available. Routes appear once GTFS schedule data has been ingested.</div>
+  <div class="empty-state">No schedule data available. Routes appear once GTFS schedule data has been ingested.</div>
   {% else %}
-  <table class="data-table">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Route</th>
-        <th>Name</th>
-        <th>Dir</th>
-        <th>Weekday</th>
-        <th>Saturday</th>
-        <th>Sunday</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for (i, row) in rows.iter().enumerate() %}
-      <tr>
-        <td style="color:var(--ink-500);font-size:0.8rem;">{{ i + 1 }}</td>
-        <td><span class="route-id">{{ row.short_name }}</span></td>
-        <td style="color:var(--ink-700);">{{ row.long_name }}</td>
-        <td style="color:var(--ink-500);font-size:0.85rem;">{{ row.direction_label() }}</td>
-        <td>
-          <span class="badge badge--{{ row.weekday_badge_variant() }}">{{ row.weekday_display() }}</span>
-        </td>
-        <td>
-          <span class="badge badge--{{ row.saturday_badge_variant() }}">{{ row.saturday_display() }}</span>
-        </td>
-        <td>
-          <span class="badge badge--{{ row.sunday_badge_variant() }}">{{ row.sunday_display() }}</span>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="schedule-grid">
+    {% for (i, row) in rows.iter().enumerate() %}
+    <div class="card schedule-card">
+      <div class="schedule-card__header">
+        <div>
+          <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
+          <div class="schedule-card__name">{{ row.long_name }}</div>
+        </div>
+        <div class="schedule-card__direction">{{ row.direction_label() }}</div>
+      </div>
+
+      <div class="schedule-card__stats">
+        <div>
+          <div class="spacing-stat-label">Min headway</div>
+          <div class="spacing-stat-num spacing-{{ row.min_headway_badge_variant() }}">{{ row.min_headway_display() }}</div>
+        </div>
+        <div>
+          <div class="spacing-stat-label">Max headway</div>
+          <div class="spacing-stat-num spacing-{{ row.max_headway_badge_variant() }}">{{ row.max_headway_display() }}</div>
+        </div>
+        <div>
+          <div class="spacing-stat-label">Service span</div>
+          <div class="spacing-stat-num spacing-neutral" style="font-size:1.35rem;">{{ row.service_span_display() }}</div>
+        </div>
+        <div>
+          <div class="spacing-stat-label">Trips</div>
+          <div class="spacing-stat-num">{{ row.trip_count_display() }}</div>
+        </div>
+      </div>
+
+      <div class="schedule-card__badges">
+        <span class="badge badge--{{ row.weekday_badge_variant() }}"><span class="schedule-card__badge-label">Weekday</span> {{ row.weekday_display() }}</span>
+        <span class="badge badge--{{ row.saturday_badge_variant() }}"><span class="schedule-card__badge-label">Saturday</span> {{ row.saturday_display() }}</span>
+        <span class="badge badge--{{ row.sunday_badge_variant() }}"><span class="schedule-card__badge-label">Sunday</span> {{ row.sunday_display() }}</span>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
   {% endif %}
 </div>

--- a/crates/server/templates/frequency_content.html
+++ b/crates/server/templates/frequency_content.html
@@ -30,30 +30,34 @@
           <div class="schedule-card__name">{{ row.long_name }}</div>
         </div>
       </div>
-
-      <div class="schedule-card__stats">
-        <div>
-          <div class="spacing-stat-label">Min headway</div>
-          <div class="spacing-stat-num spacing-{{ row.min_headway_badge_variant() }}">{{ row.min_headway_display() }}</div>
+      <div class="schedule-card__days">
+        {% if row.weekday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Weekday</div>
+          <div class="spacing-stat-num spacing-{{ row.weekday_badge_variant() }}">{{ row.weekday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.weekday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.weekday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.weekday_service_span_display() }}</span></div>
         </div>
-        <div>
-          <div class="spacing-stat-label">Max headway</div>
-          <div class="spacing-stat-num spacing-{{ row.max_headway_badge_variant() }}">{{ row.max_headway_display() }}</div>
+        {% endif %}
+        {% if row.saturday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Saturday</div>
+          <div class="spacing-stat-num spacing-{{ row.saturday_badge_variant() }}">{{ row.saturday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.saturday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.saturday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.saturday_service_span_display() }}</span></div>
         </div>
-        <div>
-          <div class="spacing-stat-label">Service span</div>
-          <div class="spacing-stat-num spacing-neutral" style="font-size:1.35rem;">{{ row.service_span_display() }}</div>
+        {% endif %}
+        {% if row.sunday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Sunday</div>
+          <div class="spacing-stat-num spacing-{{ row.sunday_badge_variant() }}">{{ row.sunday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.sunday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.sunday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.sunday_service_span_display() }}</span></div>
         </div>
-        <div>
-          <div class="spacing-stat-label">Trips</div>
-          <div class="spacing-stat-num">{{ row.trip_count_display() }}</div>
-        </div>
-      </div>
-
-      <div class="schedule-card__badges">
-        <span class="badge badge--{{ row.weekday_badge_variant() }}"><span class="schedule-card__badge-label">Weekday</span> {{ row.weekday_display() }}</span>
-        <span class="badge badge--{{ row.saturday_badge_variant() }}"><span class="schedule-card__badge-label">Saturday</span> {{ row.saturday_display() }}</span>
-        <span class="badge badge--{{ row.sunday_badge_variant() }}"><span class="schedule-card__badge-label">Sunday</span> {{ row.sunday_display() }}</span>
+        {% endif %}
       </div>
     </div>
     {% endfor %}

--- a/crates/server/templates/frequency_content.html
+++ b/crates/server/templates/frequency_content.html
@@ -29,7 +29,6 @@
           <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
           <div class="schedule-card__name">{{ row.long_name }}</div>
         </div>
-        <div class="schedule-card__direction">{{ row.direction_label() }}</div>
       </div>
 
       <div class="schedule-card__stats">

--- a/crates/worker/src/gtfs/static_feed.rs
+++ b/crates/worker/src/gtfs/static_feed.rs
@@ -224,13 +224,9 @@ async fn load_stops(tx: &mut Tx<'_>, agency_id: &AgencyId, gtfs: &Gtfs) -> Resul
     let mut rows: Vec<(String, String, String, f64, f64)> = Vec::new();
     for (id, stop) in &gtfs.stops {
         match (stop.latitude, stop.longitude) {
-            (Some(lat), Some(lon)) => rows.push((
-                agency_id.0.clone(),
-                id.clone(),
-                stop.name.clone(),
-                lat,
-                lon,
-            )),
+            (Some(lat), Some(lon)) => {
+                rows.push((agency_id.0.clone(), id.clone(), stop.name.clone(), lat, lon))
+            }
             _ => warn!("Stop {} missing coordinates, skipping", id),
         }
     }
@@ -418,9 +414,9 @@ pub(crate) async fn load_calendar_from_dates(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mobilispect_core::db::test_utils;
     use chrono::NaiveDate;
     use gtfs_structures::Calendar;
+    use mobilispect_core::db::test_utils;
     use std::collections::HashMap;
 
     // ── helpers for building minimal Gtfs structs ──────────────────────────
@@ -532,7 +528,9 @@ mod tests {
         gtfs.routes.insert("45".to_string(), make_route("45"));
 
         let mut tx = db.pool.begin().await.unwrap();
-        load_variants(&mut tx, &AgencyId::from("stm"), &gtfs).await.unwrap();
+        load_variants(&mut tx, &AgencyId::from("stm"), &gtfs)
+            .await
+            .unwrap();
         tx.commit().await.unwrap();
 
         // One variant should exist.
@@ -624,7 +622,9 @@ mod tests {
         }
 
         let mut tx = db.pool.begin().await.unwrap();
-        load_variants(&mut tx, &AgencyId::from("stm"), &gtfs).await.unwrap();
+        load_variants(&mut tx, &AgencyId::from("stm"), &gtfs)
+            .await
+            .unwrap();
         tx.commit().await.unwrap();
 
         // Two variants should exist.
@@ -686,7 +686,9 @@ mod tests {
             },
         );
 
-        load_calendar(&mut tx, &AgencyId::from("stm"), &calendar).await.unwrap();
+        load_calendar(&mut tx, &AgencyId::from("stm"), &calendar)
+            .await
+            .unwrap();
         tx.commit().await.unwrap();
 
         let rows: Vec<(String, bool, bool, bool)> = sqlx::query_as(
@@ -803,7 +805,9 @@ mod tests {
                 end_date: NaiveDate::from_ymd_opt(2026, 12, 31).unwrap(),
             },
         );
-        load_calendar(&mut tx, &AgencyId::from("stm"), &calendar).await.unwrap();
+        load_calendar(&mut tx, &AgencyId::from("stm"), &calendar)
+            .await
+            .unwrap();
 
         // calendar_dates claims WD runs on Saturday — should be ignored
         let mut calendar_dates: HashMap<String, Vec<gtfs_structures::CalendarDate>> =
@@ -849,7 +853,11 @@ fn variant_id_for(stop_ids: &[String]) -> String {
 /// Build and store route variants from already-loaded trips + scheduled_stops.
 /// Groups trips by their ordered stop sequence, assigns a deterministic variant_id,
 /// marks the variant with the most trips as primary, and links trips to their variant.
-pub(crate) async fn load_variants(tx: &mut Tx<'_>, agency_id: &AgencyId, gtfs: &Gtfs) -> Result<()> {
+pub(crate) async fn load_variants(
+    tx: &mut Tx<'_>,
+    agency_id: &AgencyId,
+    gtfs: &Gtfs,
+) -> Result<()> {
     // Collect stop sequences per trip in memory (already loaded into DB, but gtfs struct is handy).
     // key: (route_id, direction_id, stop_ids_csv) → (variant_id, trip_ids, headsign)
     let mut pattern_map: HashMap<(String, i64, String), (String, Vec<String>, Option<String>)> =

--- a/docs/superpowers/plans/2026-05-20-per-day-stats.md
+++ b/docs/superpowers/plans/2026-05-20-per-day-stats.md
@@ -1,0 +1,841 @@
+# Per-Day-Type Stats Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace combined top-decile/max/service-span stats in `RouteHeadwayRow` with per-day-type equivalents (weekday, saturday, sunday), and update the schedule card template to display per-day columns that collapse to only show active day types.
+
+**Architecture:** Struct change in `frequency/mod.rs` and template change in `frequency_content.html` are atomic — Askama compiles templates at build time against the struct's public methods, so removing old methods and updating the template must happen in the same commit. SQL rewrite follows as a separate commit. Each commit leaves the full workspace compilable.
+
+**Tech Stack:** Rust, sqlx (runtime-checked `query_as`), Askama templates, PostgreSQL window functions + `PERCENTILE_CONT`.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `crates/core/src/frequency/mod.rs` | Struct fields, SQL query, display methods, unit tests |
+| `crates/server/templates/frequency_content.html` | Card template (replace stats grid + badges with day columns) |
+| `crates/server/templates/frequency.html` | CSS (remove old classes, add day-col classes) |
+| `crates/server/src/web/handlers.rs` | E2E tests only — no handler code changes |
+
+---
+
+## Task 1: Update struct, display methods, unit tests, template, and CSS (atomic)
+
+Askama compiles the template against the Rust struct at build time. Removing display methods and updating the template must be one commit — any split would leave the workspace uncompilable.
+
+**Files:**
+- Modify: `crates/core/src/frequency/mod.rs`
+- Modify: `crates/server/templates/frequency_content.html`
+- Modify: `crates/server/templates/frequency.html`
+
+- [ ] **Step 1: Replace the `RouteHeadwayRow` struct definition**
+
+Replace the entire struct (lines 7–21 in `crates/core/src/frequency/mod.rs`) with:
+
+```rust
+#[derive(Debug, sqlx::FromRow, Serialize)]
+pub struct RouteHeadwayRow {
+    pub agency_id: AgencyId,
+    pub route_id: RouteId,
+    pub short_name: String,
+    pub long_name: String,
+    pub weekday_headway_mins: Option<f64>,
+    pub saturday_headway_mins: Option<f64>,
+    pub sunday_headway_mins: Option<f64>,
+    pub weekday_top_decile_mins: Option<f64>,
+    pub weekday_max_headway_mins: Option<f64>,
+    pub weekday_service_start_secs: Option<i64>,
+    pub weekday_service_end_secs: Option<i64>,
+    pub saturday_top_decile_mins: Option<f64>,
+    pub saturday_max_headway_mins: Option<f64>,
+    pub saturday_service_start_secs: Option<i64>,
+    pub saturday_service_end_secs: Option<i64>,
+    pub sunday_top_decile_mins: Option<f64>,
+    pub sunday_max_headway_mins: Option<f64>,
+    pub sunday_service_start_secs: Option<i64>,
+    pub sunday_service_end_secs: Option<i64>,
+}
+```
+
+- [ ] **Step 2: Replace the entire `impl RouteHeadwayRow` block**
+
+Replace everything from `impl RouteHeadwayRow {` through its closing `}` (lines 23–103) with:
+
+```rust
+impl RouteHeadwayRow {
+    pub fn headway_display(mins: Option<f64>) -> String {
+        match mins {
+            None => "—".to_string(),
+            Some(m) => format!("{:.1} min", m),
+        }
+    }
+
+    pub fn weekday_display(&self) -> String {
+        Self::headway_display(self.weekday_headway_mins)
+    }
+
+    pub fn saturday_display(&self) -> String {
+        Self::headway_display(self.saturday_headway_mins)
+    }
+
+    pub fn sunday_display(&self) -> String {
+        Self::headway_display(self.sunday_headway_mins)
+    }
+
+    pub fn weekday_top_decile_display(&self) -> String {
+        Self::headway_display(self.weekday_top_decile_mins)
+    }
+
+    pub fn weekday_max_headway_display(&self) -> String {
+        Self::headway_display(self.weekday_max_headway_mins)
+    }
+
+    pub fn saturday_top_decile_display(&self) -> String {
+        Self::headway_display(self.saturday_top_decile_mins)
+    }
+
+    pub fn saturday_max_headway_display(&self) -> String {
+        Self::headway_display(self.saturday_max_headway_mins)
+    }
+
+    pub fn sunday_top_decile_display(&self) -> String {
+        Self::headway_display(self.sunday_top_decile_mins)
+    }
+
+    pub fn sunday_max_headway_display(&self) -> String {
+        Self::headway_display(self.sunday_max_headway_mins)
+    }
+
+    pub fn weekday_service_span_display(&self) -> String {
+        Self::service_span(self.weekday_service_start_secs, self.weekday_service_end_secs)
+    }
+
+    pub fn saturday_service_span_display(&self) -> String {
+        Self::service_span(self.saturday_service_start_secs, self.saturday_service_end_secs)
+    }
+
+    pub fn sunday_service_span_display(&self) -> String {
+        Self::service_span(self.sunday_service_start_secs, self.sunday_service_end_secs)
+    }
+
+    pub fn service_span(start: Option<i64>, end: Option<i64>) -> String {
+        match (start, end) {
+            (Some(s), Some(e)) => {
+                format!("{}-{}", Self::time_display(s), Self::time_display(e))
+            }
+            _ => "—".to_string(),
+        }
+    }
+
+    fn time_display(secs: i64) -> String {
+        let hours = secs.div_euclid(3600);
+        let minutes = secs.rem_euclid(3600).div_euclid(60);
+        format!("{hours:02}:{minutes:02}")
+    }
+
+    pub fn headway_badge_variant(mins: Option<f64>) -> &'static str {
+        match mins {
+            None => "neutral",
+            Some(m) if m < 10.0 => "good",
+            Some(m) if m < 20.0 => "mixed",
+            Some(_) => "bad",
+        }
+    }
+
+    pub fn weekday_badge_variant(&self) -> &'static str {
+        Self::headway_badge_variant(self.weekday_headway_mins)
+    }
+
+    pub fn saturday_badge_variant(&self) -> &'static str {
+        Self::headway_badge_variant(self.saturday_headway_mins)
+    }
+
+    pub fn sunday_badge_variant(&self) -> &'static str {
+        Self::headway_badge_variant(self.sunday_headway_mins)
+    }
+
+    pub fn primary_headway_min(&self) -> Option<f64> {
+        self.weekday_headway_mins
+            .or(self.saturday_headway_mins)
+            .or(self.sunday_headway_mins)
+    }
+}
+```
+
+- [ ] **Step 3: Replace the entire `mod tests` block in `frequency/mod.rs`**
+
+Replace everything from `#[cfg(test)]` through the final `}` (lines 283–385) with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headway_display_none() {
+        assert_eq!(RouteHeadwayRow::headway_display(None), "—");
+    }
+
+    #[test]
+    fn headway_display_under_10() {
+        assert_eq!(RouteHeadwayRow::headway_display(Some(7.5)), "7.5 min");
+    }
+
+    #[test]
+    fn headway_display_10_or_more() {
+        assert_eq!(RouteHeadwayRow::headway_display(Some(15.0)), "15.0 min");
+    }
+
+    #[test]
+    fn headway_badge_variant_good() {
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(0.0)), "good");
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(9.9)), "good");
+    }
+
+    #[test]
+    fn headway_badge_variant_mixed() {
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(10.0)), "mixed");
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(19.9)), "mixed");
+    }
+
+    #[test]
+    fn headway_badge_variant_bad() {
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(20.0)), "bad");
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(Some(30.0)), "bad");
+    }
+
+    #[test]
+    fn headway_badge_variant_neutral() {
+        assert_eq!(RouteHeadwayRow::headway_badge_variant(None), "neutral");
+    }
+
+    fn make_row(wd: Option<f64>, sat: Option<f64>, sun: Option<f64>) -> RouteHeadwayRow {
+        RouteHeadwayRow {
+            agency_id: AgencyId::from("a"),
+            route_id: RouteId::from("r"),
+            short_name: "1".to_string(),
+            long_name: "Route 1".to_string(),
+            weekday_headway_mins: wd,
+            saturday_headway_mins: sat,
+            sunday_headway_mins: sun,
+            weekday_top_decile_mins: wd.map(|_| 5.0),
+            weekday_max_headway_mins: wd.map(|_| 30.0),
+            weekday_service_start_secs: wd.map(|_| 6 * 3600),
+            weekday_service_end_secs: wd.map(|_| 23 * 3600 + 30 * 60),
+            saturday_top_decile_mins: sat.map(|_| 10.0),
+            saturday_max_headway_mins: sat.map(|_| 40.0),
+            saturday_service_start_secs: sat.map(|_| 8 * 3600),
+            saturday_service_end_secs: sat.map(|_| 22 * 3600),
+            sunday_top_decile_mins: sun.map(|_| 15.0),
+            sunday_max_headway_mins: sun.map(|_| 50.0),
+            sunday_service_start_secs: sun.map(|_| 9 * 3600),
+            sunday_service_end_secs: sun.map(|_| 21 * 3600),
+        }
+    }
+
+    #[test]
+    fn primary_headway_min_prefers_weekday() {
+        let row = make_row(Some(8.0), Some(15.0), Some(20.0));
+        assert_eq!(row.primary_headway_min(), Some(8.0));
+    }
+
+    #[test]
+    fn primary_headway_min_falls_back_to_saturday() {
+        let row = make_row(None, Some(15.0), Some(20.0));
+        assert_eq!(row.primary_headway_min(), Some(15.0));
+    }
+
+    #[test]
+    fn primary_headway_min_falls_back_to_sunday() {
+        let row = make_row(None, None, Some(20.0));
+        assert_eq!(row.primary_headway_min(), Some(20.0));
+    }
+
+    #[test]
+    fn primary_headway_min_all_none() {
+        let row = make_row(None, None, None);
+        assert_eq!(row.primary_headway_min(), None);
+    }
+
+    #[test]
+    fn service_span_none_none_returns_dash() {
+        assert_eq!(RouteHeadwayRow::service_span(None, None), "—");
+    }
+
+    #[test]
+    fn weekday_service_span_display_formats_correctly() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_service_span_display(), "06:00-23:30");
+    }
+
+    #[test]
+    fn weekday_service_span_display_wraps_after_midnight() {
+        let mut row = make_row(Some(8.0), None, None);
+        row.weekday_service_end_secs = Some(25 * 3600 + 15 * 60);
+        assert_eq!(row.weekday_service_span_display(), "06:00-25:15");
+    }
+
+    #[test]
+    fn saturday_service_span_display_formats_correctly() {
+        let row = make_row(None, Some(15.0), None);
+        assert_eq!(row.saturday_service_span_display(), "08:00-22:00");
+    }
+
+    #[test]
+    fn sunday_service_span_display_formats_correctly() {
+        let row = make_row(None, None, Some(20.0));
+        assert_eq!(row.sunday_service_span_display(), "09:00-21:00");
+    }
+
+    #[test]
+    fn weekday_top_decile_and_max_display() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_top_decile_display(), "5.0 min");
+        assert_eq!(row.weekday_max_headway_display(), "30.0 min");
+    }
+}
+```
+
+- [ ] **Step 4: Replace `frequency_content.html` entirely**
+
+Write the full new content to `crates/server/templates/frequency_content.html`:
+
+```html
+<!-- HTMX target: id="freq-content" must match hx-target on every control link -->
+<div id="freq-content" hx-indicator="#freq-loading">
+  <div class="control-row" style="margin-bottom:1.5rem;">
+    <span class="control-label">Agency:</span>
+    <a href="/schedule"
+       hx-get="/schedule"
+       hx-target="#freq-content"
+       hx-swap="outerHTML"
+       hx-push-url="true"
+       class="{% if active_agency.is_empty() %}active{% endif %}">All</a>
+    {% for (slug, name) in &agencies %}
+    <a href="/schedule?agency={{ slug }}"
+       hx-get="/schedule?agency={{ slug }}"
+       hx-target="#freq-content"
+       hx-swap="outerHTML"
+       hx-push-url="true"
+       class="{% if active_agency == *slug %}active{% endif %}">{{ name }}</a>
+    {% endfor %}
+  </div>
+
+  {% if rows.is_empty() %}
+  <div class="empty-state">No schedule data available. Routes appear once GTFS schedule data has been ingested.</div>
+  {% else %}
+  <div class="schedule-grid">
+    {% for (i, row) in rows.iter().enumerate() %}
+    <div class="card schedule-card">
+      <div class="schedule-card__header">
+        <div>
+          <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
+          <div class="schedule-card__name">{{ row.long_name }}</div>
+        </div>
+      </div>
+      <div class="schedule-card__days">
+        {% if row.weekday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Weekday</div>
+          <div class="spacing-stat-num spacing-{{ row.weekday_badge_variant() }}">{{ row.weekday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.weekday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.weekday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.weekday_service_span_display() }}</span></div>
+        </div>
+        {% endif %}
+        {% if row.saturday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Saturday</div>
+          <div class="spacing-stat-num spacing-{{ row.saturday_badge_variant() }}">{{ row.saturday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.saturday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.saturday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.saturday_service_span_display() }}</span></div>
+        </div>
+        {% endif %}
+        {% if row.sunday_headway_mins.is_some() %}
+        <div class="day-col">
+          <div class="day-col__hdr">Sunday</div>
+          <div class="spacing-stat-num spacing-{{ row.sunday_badge_variant() }}">{{ row.sunday_display() }}</div>
+          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.sunday_top_decile_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.sunday_max_headway_display() }}</span></div>
+          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.sunday_service_span_display() }}</span></div>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+```
+
+- [ ] **Step 5: Update CSS in `frequency.html`**
+
+In `crates/server/templates/frequency.html`, replace the block from `.schedule-card__stats {` through the closing `}` of the `@media` block (the block spanning lines 68–96) with:
+
+```css
+.schedule-card__days {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 6px;
+  border-top: 1px solid var(--line-soft);
+  padding-top: 0.75rem;
+}
+.day-col {
+  background: var(--bg-subtle, #F4F4EF);
+  border-radius: 8px;
+  padding: 8px 6px;
+  text-align: center;
+}
+.day-col .spacing-stat-num {
+  font-size: 1.3rem;
+  margin-bottom: 4px;
+}
+.day-col__hdr {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 4px;
+}
+.day-col__stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 3px;
+  gap: 4px;
+  font-size: 0.72rem;
+  color: var(--ink-500);
+}
+.day-col__lbl {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-400);
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .schedule-grid {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+- [ ] **Step 6: Build to verify the whole workspace compiles**
+
+```bash
+cargo build
+```
+
+Expected: success. Both crates compile. The SQL still returns the old columns so E2E tests that hit the DB will fail at runtime with a column-not-found error — that's expected and fixed in Task 2.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+cargo test -p mobilispect-core frequency::
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/core/src/frequency/mod.rs \
+        crates/server/templates/frequency_content.html \
+        crates/server/templates/frequency.html
+git commit -m "refactor(frequency): per-day struct fields, display methods, and card template"
+```
+
+---
+
+## Task 2: Rewrite SQL query
+
+**Files:**
+- Modify: `crates/core/src/frequency/mod.rs` (the `sql` string inside `route_headways`)
+
+- [ ] **Step 1: Replace the entire `sql` string in `route_headways()`**
+
+Replace everything from `let sql = "WITH` through the closing `";` with:
+
+```rust
+    let sql = "WITH
+trip_times AS (
+    SELECT
+        t.agency_id,
+        t.route_id,
+        COALESCE(t.direction_id, 0)                              AS direction_id,
+        t.trip_id,
+        t.service_id,
+        MIN((
+            SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
+          + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
+          + SPLIT_PART(ss.departure_time, ':', 3)::INT
+        )::BIGINT)                                               AS start_secs,
+        MAX((
+            SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
+          + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
+          + SPLIT_PART(ss.departure_time, ':', 3)::INT
+        )::BIGINT)                                               AS end_secs,
+        (c.monday OR c.tuesday OR c.wednesday
+         OR c.thursday OR c.friday)                             AS is_weekday,
+        c.saturday                                               AS is_saturday,
+        c.sunday                                                 AS is_sunday
+    FROM trips t
+    JOIN calendar c
+      ON c.agency_id = t.agency_id AND c.service_id = t.service_id
+    JOIN scheduled_stops ss
+      ON ss.agency_id = t.agency_id AND ss.trip_id = t.trip_id
+    WHERE (c.monday OR c.tuesday OR c.wednesday OR c.thursday
+           OR c.friday OR c.saturday OR c.sunday)
+    GROUP BY
+        t.agency_id,
+        t.route_id,
+        COALESCE(t.direction_id, 0),
+        t.trip_id,
+        t.service_id,
+        is_weekday,
+        c.saturday,
+        c.sunday
+),
+wd_gaps AS (
+    SELECT agency_id, route_id, direction_id,
+        LEAD(start_secs) OVER (
+            PARTITION BY agency_id, route_id, direction_id, service_id
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
+    WHERE is_weekday
+),
+sat_gaps AS (
+    SELECT agency_id, route_id, direction_id,
+        LEAD(start_secs) OVER (
+            PARTITION BY agency_id, route_id, direction_id, service_id
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
+    WHERE is_saturday
+),
+sun_gaps AS (
+    SELECT agency_id, route_id, direction_id,
+        LEAD(start_secs) OVER (
+            PARTITION BY agency_id, route_id, direction_id, service_id
+            ORDER BY start_secs
+        ) - start_secs AS gap_secs
+    FROM trip_times
+    WHERE is_sunday
+),
+wd_headways AS (
+    SELECT agency_id, route_id,
+        AVG(gap_secs::double precision) / 60.0 AS weekday_headway_mins
+    FROM wd_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sat_headways AS (
+    SELECT agency_id, route_id,
+        AVG(gap_secs::double precision) / 60.0 AS saturday_headway_mins
+    FROM sat_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sun_headways AS (
+    SELECT agency_id, route_id,
+        AVG(gap_secs::double precision) / 60.0 AS sunday_headway_mins
+    FROM sun_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+wd_gap_summary AS (
+    SELECT agency_id, route_id,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS weekday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS weekday_max_headway_mins
+    FROM wd_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sat_gap_summary AS (
+    SELECT agency_id, route_id,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS saturday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS saturday_max_headway_mins
+    FROM sat_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sun_gap_summary AS (
+    SELECT agency_id, route_id,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS sunday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS sunday_max_headway_mins
+    FROM sun_gaps
+    WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+wd_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS weekday_service_start_secs,
+        MAX(end_secs)   AS weekday_service_end_secs
+    FROM trip_times
+    WHERE is_weekday
+    GROUP BY agency_id, route_id
+),
+sat_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS saturday_service_start_secs,
+        MAX(end_secs)   AS saturday_service_end_secs
+    FROM trip_times
+    WHERE is_saturday
+    GROUP BY agency_id, route_id
+),
+sun_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS sunday_service_start_secs,
+        MAX(end_secs)   AS sunday_service_end_secs
+    FROM trip_times
+    WHERE is_sunday
+    GROUP BY agency_id, route_id
+),
+route_dirs AS (
+    SELECT DISTINCT
+        tt.agency_id,
+        tt.route_id,
+        r.short_name,
+        r.long_name
+    FROM trip_times tt
+    JOIN routes r ON r.agency_id = tt.agency_id AND r.route_id = tt.route_id
+)
+SELECT
+    rd.agency_id,
+    rd.route_id,
+    rd.short_name,
+    rd.long_name,
+    wd.weekday_headway_mins,
+    sat.saturday_headway_mins,
+    sun.sunday_headway_mins,
+    wgs.weekday_top_decile_mins,
+    wgs.weekday_max_headway_mins,
+    ws.weekday_service_start_secs,
+    ws.weekday_service_end_secs,
+    sgs.saturday_top_decile_mins,
+    sgs.saturday_max_headway_mins,
+    ss_sat.saturday_service_start_secs,
+    ss_sat.saturday_service_end_secs,
+    sugs.sunday_top_decile_mins,
+    sugs.sunday_max_headway_mins,
+    ss_sun.sunday_service_start_secs,
+    ss_sun.sunday_service_end_secs
+FROM route_dirs rd
+LEFT JOIN wd_headways wd
+  ON wd.agency_id = rd.agency_id
+ AND wd.route_id  = rd.route_id
+LEFT JOIN sat_headways sat
+  ON sat.agency_id = rd.agency_id
+ AND sat.route_id  = rd.route_id
+LEFT JOIN sun_headways sun
+  ON sun.agency_id = rd.agency_id
+ AND sun.route_id  = rd.route_id
+LEFT JOIN wd_gap_summary wgs
+  ON wgs.agency_id = rd.agency_id
+ AND wgs.route_id  = rd.route_id
+LEFT JOIN sat_gap_summary sgs
+  ON sgs.agency_id = rd.agency_id
+ AND sgs.route_id  = rd.route_id
+LEFT JOIN sun_gap_summary sugs
+  ON sugs.agency_id = rd.agency_id
+ AND sugs.route_id  = rd.route_id
+LEFT JOIN wd_service ws
+  ON ws.agency_id = rd.agency_id
+ AND ws.route_id  = rd.route_id
+LEFT JOIN sat_service ss_sat
+  ON ss_sat.agency_id = rd.agency_id
+ AND ss_sat.route_id  = rd.route_id
+LEFT JOIN sun_service ss_sun
+  ON ss_sun.agency_id = rd.agency_id
+ AND ss_sun.route_id  = rd.route_id
+WHERE ($1::text IS NULL OR rd.agency_id = $1)
+  AND (
+      wd.weekday_headway_mins IS NOT NULL
+   OR sat.saturday_headway_mins IS NOT NULL
+   OR sun.sunday_headway_mins IS NOT NULL
+  )
+ORDER BY
+    rd.agency_id,
+    COALESCE(
+        wd.weekday_headway_mins,
+        sat.saturday_headway_mins,
+        sun.sunday_headway_mins
+    ) ASC NULLS LAST,
+    CASE WHEN rd.short_name ~ '^[0-9]+$'
+         THEN rd.short_name::INTEGER ELSE NULL END NULLS LAST,
+    rd.short_name";
+```
+
+- [ ] **Step 2: Run existing E2E tests**
+
+```bash
+cargo test -p mobilispect-server schedule_page_renders_route_schedule_cards
+cargo test -p mobilispect-server schedule_page_uses_top_decile
+cargo test -p mobilispect-server schedule_page_computes_headways
+cargo test -p mobilispect-server schedule_page_combines_directions
+```
+
+Expected: all pass. The values `06:00-07:00`, `11.0 min`, and `20.0 min` are still produced by the new per-day CTEs (they are now weekday-scoped, which matches the seed data). The assertions `html.contains("Max headway")` and `html.contains("Service span")` now fail because the template now uses "Max" and "Span" — fix those in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/src/frequency/mod.rs
+git commit -m "feat(frequency): compute top-decile, max, and service span per day type"
+```
+
+---
+
+## Task 3: Write failing E2E test for Saturday column rendering
+
+**Files:**
+- Modify: `crates/server/src/web/handlers.rs`
+
+- [ ] **Step 1: Add the new test at the end of `mod e2e_tests`**
+
+Insert before the final closing `}` of `mod e2e_tests`:
+
+```rust
+#[tokio::test]
+async fn schedule_page_renders_saturday_column_when_saturday_service_exists() {
+    let td = test_utils::setup().await;
+    sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+    )
+    .execute(&td.db.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO calendar VALUES ('0', 'SAT', false, false, false, false, false, true, false)",
+    )
+    .execute(&td.db.pool)
+    .await
+    .unwrap();
+
+    for (trip_id, service_id, dep_time, arr_time) in [
+        ("T1", "WD", "06:00:00", "06:30:00"),
+        ("T2", "WD", "06:10:00", "06:40:00"),
+        ("T3", "SAT", "09:00:00", "09:30:00"),
+        ("T4", "SAT", "09:20:00", "09:50:00"),
+    ] {
+        sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', $2, 0, 'Downtown')")
+            .bind(trip_id)
+            .bind(service_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
+            .bind(trip_id)
+            .bind(dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
+            .bind(trip_id)
+            .bind(arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+    }
+
+    let state = AppState {
+        db: td.db,
+        config: test_config(),
+    };
+    let app = build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/schedule")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(html.contains("Weekday"), "weekday column should render");
+    assert!(html.contains("Saturday"), "saturday column should render");
+    assert!(!html.contains("Sunday"), "sunday column should not render");
+    assert!(
+        html.contains("09:00-09:50"),
+        "saturday service span should be 09:00-09:50"
+    );
+}
+```
+
+- [ ] **Step 2: Run to confirm it passes (the template already renders per-day columns from Task 1)**
+
+```bash
+cargo test -p mobilispect-server schedule_page_renders_saturday_column
+```
+
+Expected: PASS — the template from Task 1 already renders Saturday column when `saturday_headway_mins` is `Some`, and the SQL from Task 2 now provides `saturday_service_start_secs`/`saturday_service_end_secs`.
+
+---
+
+## Task 4: Fix broken label assertions in E2E tests
+
+**Files:**
+- Modify: `crates/server/src/web/handlers.rs`
+
+- [ ] **Step 1: Update the two broken assertions in `schedule_page_renders_route_schedule_cards`**
+
+Find this assertion block in `schedule_page_renders_route_schedule_cards` (look for `assert!(html.contains("Max headway"))`):
+
+```rust
+assert!(html.contains("schedule-card"));
+assert!(html.contains("Top 10%"));
+assert!(html.contains("Max headway"));
+assert!(html.contains("Service span"));
+assert!(html.contains("06:00-07:00"));
+assert!(html.contains("11.0 min"));
+assert!(html.contains("20.0 min"));
+```
+
+Replace with:
+
+```rust
+assert!(html.contains("schedule-card"));
+assert!(html.contains("Top 10%"));
+assert!(html.contains("Max"));
+assert!(html.contains("Span"));
+assert!(html.contains("06:00-07:00"));
+assert!(html.contains("11.0 min"));
+assert!(html.contains("20.0 min"));
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cargo test -p mobilispect-core
+cargo test -p mobilispect-server
+```
+
+Expected: all tests pass, no failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/server/src/web/handlers.rs
+git commit -m "test(frequency): update label assertions for new schedule card layout"
+```

--- a/docs/superpowers/specs/2026-05-20-per-day-stats-design.md
+++ b/docs/superpowers/specs/2026-05-20-per-day-stats-design.md
@@ -1,0 +1,167 @@
+# Per-Day-Type Stats Design
+
+**Date:** 2026-05-20
+**Status:** Approved
+
+## Problem
+
+`RouteHeadwayRow` currently computes `top_decile_headway_mins`, `max_headway_mins`, `service_start_secs`, and `service_end_secs` by pooling gaps from all day types (weekday + Saturday + Sunday) into one combined set. This makes the values misleading — a route's "max headway" could come from Sunday when the analyst is looking at weekday service.
+
+## Goal
+
+Compute top-decile headway, max headway, and service span separately for each day type. Drop `trip_count` from the card entirely.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Card layout | Per-day columns (B: three equal columns, one per active day type) |
+| Missing day types | Collapse — only render columns for day types with actual service |
+| `trip_count` | Drop from struct and card |
+
+## Data Model
+
+### Removed fields from `RouteHeadwayRow`
+
+- `top_decile_headway_mins: Option<f64>`
+- `max_headway_mins: Option<f64>`
+- `service_start_secs: Option<i64>`
+- `service_end_secs: Option<i64>`
+- `trip_count: i64`
+
+### Added fields (×3 day types: weekday / saturday / sunday)
+
+```rust
+pub weekday_top_decile_mins:    Option<f64>,
+pub weekday_max_headway_mins:   Option<f64>,
+pub weekday_service_start_secs: Option<i64>,
+pub weekday_service_end_secs:   Option<i64>,
+
+pub saturday_top_decile_mins:    Option<f64>,
+pub saturday_max_headway_mins:   Option<f64>,
+pub saturday_service_start_secs: Option<i64>,
+pub saturday_service_end_secs:   Option<i64>,
+
+pub sunday_top_decile_mins:    Option<f64>,
+pub sunday_max_headway_mins:   Option<f64>,
+pub sunday_service_start_secs: Option<i64>,
+pub sunday_service_end_secs:   Option<i64>,
+```
+
+A per-day column is shown in the template if and only if the day's avg headway field is `Some`. The per-day top-decile/max/span fields will be `None` exactly when the avg headway is `None`, so no separate guard is needed.
+
+### Kept unchanged
+
+`agency_id`, `route_id`, `short_name`, `long_name`, `weekday_headway_mins`, `saturday_headway_mins`, `sunday_headway_mins`, `primary_headway_min()`.
+
+## SQL
+
+### Removed CTEs
+
+- `all_gaps` (union of wd/sat/sun gaps)
+- `gap_summary` (combined PERCENTILE_CONT + MAX across all day types)
+- `service_summary` (combined MIN/MAX start/end + COUNT)
+
+### Added CTEs
+
+```sql
+wd_gap_summary AS (
+    SELECT agency_id, route_id,
+        PERCENTILE_CONT(0.10) WITHIN GROUP (ORDER BY gap_secs::double precision) / 60.0
+            AS weekday_top_decile_mins,
+        MAX(gap_secs::double precision) / 60.0 AS weekday_max_headway_mins
+    FROM wd_gaps WHERE gap_secs > 0
+    GROUP BY agency_id, route_id
+),
+sat_gap_summary AS ( -- same shape, sat_ prefix ),
+sun_gap_summary AS ( -- same shape, sun_ prefix ),
+
+wd_service AS (
+    SELECT agency_id, route_id,
+        MIN(start_secs) AS weekday_service_start_secs,
+        MAX(end_secs)   AS weekday_service_end_secs
+    FROM trip_times WHERE is_weekday
+    GROUP BY agency_id, route_id
+),
+sat_service AS ( -- same shape, saturday_ prefix ),
+sun_service AS ( -- same shape, sunday_ prefix ),
+```
+
+The final `SELECT` grows from 12 columns to 19 (adds 12 per-day columns, drops 5 old columns). The `LEFT JOIN` chain grows by 6 joins (one per new CTE). The `ORDER BY` clause is unchanged.
+
+## Display Methods
+
+### Removed
+
+- `top_decile_headway_display()`, `top_decile_headway_badge_variant()`
+- `max_headway_display()`, `max_headway_badge_variant()`
+- `service_span_display()`
+- `trip_count_display()`
+
+### Added
+
+```rust
+// Static helper (replaces inline logic in the old service_span_display)
+fn service_span(start: Option<i64>, end: Option<i64>) -> String
+
+// Per-day display methods (×3 day types)
+pub fn weekday_top_decile_display(&self) -> String   // → headway_display(weekday_top_decile_mins)
+pub fn weekday_max_headway_display(&self) -> String  // → headway_display(weekday_max_headway_mins)
+pub fn weekday_service_span_display(&self) -> String // → service_span(weekday_start, weekday_end)
+// …saturday_ and sunday_ variants follow same pattern
+```
+
+All new methods delegate to the existing static helpers `headway_display` and the new `service_span`. No new formatting logic.
+
+## Template (`frequency_content.html`)
+
+The `schedule-card__stats` div (4-stat grid) and `schedule-card__badges` div (3 badges) are replaced by a single day-column group per card:
+
+```html
+<div class="schedule-card__days">
+  {% if row.weekday_headway_mins.is_some() %}
+  <div class="day-col">
+    <div class="day-col__hdr">Weekday</div>
+    <div class="day-col__avg spacing-{{ row.weekday_badge_variant() }}">
+      {{ row.weekday_display() }}
+    </div>
+    <div class="day-col__stat">
+      <span class="day-col__lbl">Top 10%</span>
+      <span>{{ row.weekday_top_decile_display() }}</span>
+    </div>
+    <div class="day-col__stat">
+      <span class="day-col__lbl">Max</span>
+      <span>{{ row.weekday_max_headway_display() }}</span>
+    </div>
+    <div class="day-col__stat">
+      <span class="day-col__lbl">Span</span>
+      <span>{{ row.weekday_service_span_display() }}</span>
+    </div>
+  </div>
+  {% endif %}
+  {# same block for saturday and sunday #}
+</div>
+```
+
+CSS for `.schedule-card__days`: `display: grid; grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)); gap: 6px;` — collapses naturally to 1, 2, or 3 columns depending on active day types.
+
+The `schedule-card__stats` and `schedule-card__badges` CSS class definitions (and their responsive overrides) are removed from the `<style>` block in `crates/server/templates/frequency.html`. New `.schedule-card__days`, `.day-col`, `.day-col__hdr`, `.day-col__avg`, `.day-col__stat`, `.day-col__lbl` rules are added there. The `schedule-card__badge-label` class is also removed.
+
+## Tests
+
+### Unit tests (`frequency/mod.rs`)
+
+- `make_row` helper updated: removes 5 old fields, adds 12 new fields with representative values.
+- Existing tests for `headway_display`, `headway_badge_variant`, `primary_headway_min` adapted to new struct shape.
+- New tests:
+  - `service_span_none_none_returns_dash`
+  - `weekday_service_span_display_formats_correctly`
+  - `saturday_service_span_display_formats_correctly`
+  - `sunday_service_span_display_formats_correctly`
+  - `weekday_top_decile_and_max_display`
+
+### E2E tests (`handlers.rs`)
+
+- `schedule_page_renders_route_schedule_cards`: assertions on `"06:00-07:00"`, `"11.0 min"`, `"20.0 min"` stay valid — values now come from weekday-scoped fields. No structural changes needed.
+- New test `schedule_page_renders_saturday_column_when_saturday_service_exists`: seeds weekday + Saturday calendar rows, asserts both columns render.
+- Remove assertion `html.contains("Top 10%")` from `schedule_page_uses_top_decile_headway_instead_of_minimum` and `schedule_page_computes_headways_within_each_service_id` if the label text changes in the template; update to match new label text.


### PR DESCRIPTION
## Summary

- Add route schedule cards showing combined directions per route
- Compute top-decile headway, max headway, and service span broken out by day type (weekday, Saturday, Sunday)
- Refactor frequency structs to per-day fields with display methods
- Add E2E tests for schedule card layout and Saturday column rendering
- Add project-level Claude Code hooks: `cargo fmt` on Rust file edits, `cargo test` gate before `git push`/`cargo publish`

## Test plan

- [ ] `cargo test` passes
- [ ] Frequency page renders weekday / Saturday / Sunday columns correctly
- [ ] Schedule cards show combined route directions
- [ ] Saturday column renders when Saturday service exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)