### PR TITLE
chore: fix cargo audit — update deps and suppress unfixable advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071: Marvin Attack timing sidechannel in the `rsa` crate.
+    # No fix is available upstream. `rsa` is pulled in by `sqlx-mysql` which is
+    # an unconditional compile-time dependency of `sqlx-macros-core`. This project
+    # uses PostgreSQL exclusively; the MySQL driver (and therefore the vulnerable
+    # RSA code) is never executed at runtime.
+    "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2020-0071: Potential segfault in `time 0.1.x` when the TZ
+    # environment variable is mutated concurrently. `time 0.1.45` is a transitive
+    # dependency of `zip 0.5.x` which is used by `gtfs-structures 0.26`. Upgrading
+    # gtfs-structures to a version that drops this dependency is a large migration
+    # tracked separately. The project never mutates TZ at runtime, so the unsafe
+    # code path cannot be triggered.
+    "RUSTSEC-2020-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,15 +1788,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1826,9 +1825,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2072,9 +2071,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2376,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Update `openssl` 0.10.76 → 0.10.80 and `openssl-sys` 0.9.112 → 0.9.116 (security)
- Update `rustls-webpki` 0.103.10 → 0.103.13 (security)
- Update `rand` 0.8.5 → 0.8.6
- Add `.cargo/audit.toml` to suppress two advisories that have no actionable fix

## Why

`cargo audit` (run by `rustsec/audit-check@v2` in CI) was failing with 2 vulnerabilities. The openssl and rustls-webpki bumps resolve the ones that had fixes available. Two remaining advisories cannot be fixed upstream yet:

| Advisory | Crate | Root cause | Justification for suppression |
|----------|-------|------------|-------------------------------|
| RUSTSEC-2023-0071 | `rsa 0.9.10` | `sqlx-macros-core` unconditionally links `sqlx-mysql` as a proc-macro dep | No fix available upstream; MySQL driver is never executed at runtime — project is PostgreSQL-only |
| RUSTSEC-2020-0071 | `time 0.1.45` | `gtfs-structures 0.26` → `zip 0.5` → `time 0.1.x` | Upgrading `gtfs-structures` (0.26 → 0.47) is a larger migration tracked separately; the TZ-mutation code path is never triggered |

## Test plan

- [ ] CI `Audit` job passes (`rustsec/audit-check@v2`)
- [ ] CI `Lint` and `Test` jobs pass (only `Cargo.lock` and a new config file changed — no production code touched)