### PR TITLE
Fix all clippy warnings (-D warnings clean)

### DIFF
--- a/crates/core/src/on_time_performance/trend.rs
+++ b/crates/core/src/on_time_performance/trend.rs
@@ -5,7 +5,7 @@ use crate::db::Database;
 use crate::ids::{AgencyId, RouteId};
 
 /// One day of combined on-time and speed data for a route.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct DailyTrendPoint {
     pub service_date: String,
     pub on_time_pct: Option<f64>,
@@ -84,7 +84,7 @@ pub async fn route_trend(
     };
 
     // Daily points: LEFT JOIN speed (averaged across directions) onto on-time data.
-    let points: Vec<(String, Option<f64>, Option<f64>, Option<f64>)> = sqlx::query_as(
+    let trend_days: Vec<DailyTrendPoint> = sqlx::query_as(
         "SELECT
            rd.service_date,
            rd.on_time_pct,
@@ -104,21 +104,9 @@ pub async fn route_trend(
     .fetch_all(&db.pool)
     .await?;
 
-    if points.is_empty() {
+    if trend_days.is_empty() {
         return Ok(None);
     }
-
-    let trend_days = points
-        .into_iter()
-        .map(
-            |(service_date, on_time_pct, avg_delay_secs, actual_speed_mps)| DailyTrendPoint {
-                service_date,
-                on_time_pct,
-                avg_delay_secs,
-                actual_speed_mps,
-            },
-        )
-        .collect();
 
     Ok(Some(RouteTrend {
         route_id: route_id.clone(),

--- a/crates/core/src/speed_analysis/mod.rs
+++ b/crates/core/src/speed_analysis/mod.rs
@@ -6,6 +6,9 @@ use crate::config::AgencyConfig;
 use crate::db::Database;
 use crate::ids::{AgencyId, DirectionId, RouteId, VariantId};
 
+type SpeedPoint = (String, f64, Option<f64>);
+type DayBuckets = (Vec<SpeedPoint>, Vec<SpeedPoint>, Vec<SpeedPoint>);
+
 pub mod card;
 pub mod detail;
 pub use card::{
@@ -288,14 +291,8 @@ fn build_direction_trends(rows: Vec<SpeedTrendRow>) -> Vec<DirectionSpeedTrend> 
     use chrono::Datelike;
     use std::str::FromStr;
 
-    let mut map: std::collections::HashMap<
-        DirectionId,
-        (
-            Vec<(String, f64, Option<f64>)>,
-            Vec<(String, f64, Option<f64>)>,
-            Vec<(String, f64, Option<f64>)>,
-        ),
-    > = std::collections::HashMap::new();
+    let mut map: std::collections::HashMap<DirectionId, DayBuckets> =
+        std::collections::HashMap::new();
 
     for row in rows {
         // num_days_from_sunday(): 0 = Sunday, 1 = Monday, …, 6 = Saturday
@@ -353,14 +350,8 @@ fn build_variant_trends(rows: Vec<SpeedTrendVariantRow>) -> Vec<VariantSpeedTren
     use chrono::Datelike;
     use std::str::FromStr;
 
-    let mut map: std::collections::HashMap<
-        VariantId,
-        (
-            Vec<(String, f64, Option<f64>)>,
-            Vec<(String, f64, Option<f64>)>,
-            Vec<(String, f64, Option<f64>)>,
-        ),
-    > = std::collections::HashMap::new();
+    let mut map: std::collections::HashMap<VariantId, DayBuckets> =
+        std::collections::HashMap::new();
 
     for row in rows {
         let dow = chrono::NaiveDate::from_str(&row.service_date)

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -5,7 +5,6 @@ use axum::{
     response::Html,
 };
 use serde::Deserialize;
-use serde_json;
 
 use crate::web::AppState;
 use mobilispect_core::ids::{AgencyId, RouteId};

--- a/crates/worker/src/feed_ingestion/realtime.rs
+++ b/crates/worker/src/feed_ingestion/realtime.rs
@@ -8,6 +8,7 @@ use mobilispect_core::ids::AgencyId;
 // GTFS-RT protobuf types — generated from the official .proto file
 // Include the generated code from build.rs output
 pub mod proto {
+    #![allow(clippy::enum_variant_names)]
     include!(concat!(env!("OUT_DIR"), "/transit_realtime.rs"));
 }
 
@@ -131,12 +132,8 @@ async fn store_trip_updates(
                 .as_ref()
                 .and_then(|d| d.delay)
                 .map(|d| d as i64);
-            let arrival_time_unix = stu.arrival.as_ref().and_then(|a| a.time).map(|t| t as i64);
-            let departure_time_unix = stu
-                .departure
-                .as_ref()
-                .and_then(|d| d.time)
-                .map(|t| t as i64);
+            let arrival_time_unix = stu.arrival.as_ref().and_then(|a| a.time);
+            let departure_time_unix = stu.departure.as_ref().and_then(|d| d.time);
 
             sqlx::query!(
                 "INSERT INTO stop_time_events

--- a/crates/worker/src/feed_ingestion/static_feed.rs
+++ b/crates/worker/src/feed_ingestion/static_feed.rs
@@ -11,6 +11,12 @@ use mobilispect_core::config::AgencyConfig;
 use mobilispect_core::db::Database;
 use mobilispect_core::ids::AgencyId;
 
+type TripRow = (String, String, String, String, Option<i64>, Option<String>);
+type PatternKey = (String, i64, String);
+type PatternVal = (String, Vec<String>, Option<String>);
+#[cfg(test)]
+type CalendarRow = (String, bool, bool, bool, bool, bool, bool, bool);
+
 /// Rows to bundle per INSERT statement.
 const CHUNK: usize = 500;
 
@@ -24,7 +30,7 @@ pub async fn load_if_needed(db: &Database, agency: &AgencyConfig) -> Result<()> 
     if let Some(last) = last_download {
         let last_date = chrono::NaiveDate::parse_from_str(&last, "%Y-%m-%d").ok();
         let today = Utc::now().date_naive();
-        if let Some(date) = last_date.filter(|d| *d >= today) {
+        if let Some(_date) = last_date.filter(|d| *d >= today) {
             info!("Static GTFS already downloaded today, skipping download");
             return Ok(());
         }
@@ -179,7 +185,7 @@ async fn load_routes(tx: &mut Tx<'_>, agency_id: &AgencyId, gtfs: &Gtfs) -> Resu
 }
 
 async fn load_trips(tx: &mut Tx<'_>, agency_id: &AgencyId, gtfs: &Gtfs) -> Result<()> {
-    let rows: Vec<(String, String, String, String, Option<i64>, Option<String>)> = gtfs
+    let rows: Vec<TripRow> = gtfs
         .trips
         .iter()
         .map(|(id, t)| {
@@ -408,6 +414,179 @@ pub(crate) async fn load_calendar_from_dates(
         "Synthesized {} calendar entries from calendar_dates",
         synthesized
     );
+    Ok(())
+}
+
+/// Compute a deterministic variant_id for a given stop sequence.
+/// Input: "{stop1_id},{stop2_id},..." — route and direction are intentionally
+/// excluded so the same physical pattern gets the same ID regardless of
+/// how the agency numbers or labels the route.
+fn variant_id_for(stop_ids: &[String]) -> String {
+    let input = stop_ids.join(",");
+    let digest = Sha256::digest(input.as_bytes());
+    hex::encode(&digest[..16])
+}
+
+/// Build and store route variants from already-loaded trips + scheduled_stops.
+/// Groups trips by their ordered stop sequence, assigns a deterministic variant_id,
+/// marks the variant with the most trips as primary, and links trips to their variant.
+pub(crate) async fn load_variants(
+    tx: &mut Tx<'_>,
+    agency_id: &AgencyId,
+    gtfs: &Gtfs,
+) -> Result<()> {
+    // Collect stop sequences per trip in memory (already loaded into DB, but gtfs struct is handy).
+    // key: (route_id, direction_id, stop_ids_csv) → (variant_id, trip_ids, headsign)
+    let mut pattern_map: HashMap<PatternKey, PatternVal> = HashMap::new();
+
+    for (trip_id, trip) in &gtfs.trips {
+        let direction_id = trip
+            .direction_id
+            .as_ref()
+            .map(direction_to_int)
+            .unwrap_or(0);
+
+        let stop_ids: Vec<String> = trip
+            .stop_times
+            .iter()
+            .map(|st| st.stop.id.clone())
+            .collect();
+        // stop_times from gtfs-structures are already ordered by stop_sequence
+        let stop_ids_csv = stop_ids.join(",");
+
+        let key = (trip.route_id.clone(), direction_id, stop_ids_csv.clone());
+        let vid = variant_id_for(&stop_ids);
+
+        let entry = pattern_map.entry(key).or_insert_with(|| {
+            let headsign = trip.trip_headsign.clone();
+            (vid.clone(), Vec::new(), headsign)
+        });
+        entry.1.push(trip_id.clone());
+    }
+
+    // Determine is_primary per (route_id, direction_id): variant with highest trip_count.
+    // Build: (route_id, direction_id) → max trip_count seen so far
+    let mut primary_map: HashMap<(String, i64), (usize, String)> = HashMap::new();
+    for ((route_id, direction_id, _), (vid, trip_ids, _)) in &pattern_map {
+        let count = trip_ids.len();
+        let entry = primary_map
+            .entry((route_id.clone(), *direction_id))
+            .or_insert((0, vid.clone()));
+        if count > entry.0 || (count == entry.0 && vid < &entry.1) {
+            *entry = (count, vid.clone());
+        }
+    }
+
+    for ((route_id, direction_id, stop_ids_csv), (vid, trip_ids, headsign)) in &pattern_map {
+        let stop_ids: Vec<&str> = stop_ids_csv.split(',').collect();
+        let stop_count = stop_ids.len() as i64;
+        let trip_count = trip_ids.len() as i64;
+        let is_primary = primary_map
+            .get(&(route_id.clone(), *direction_id))
+            .map(|(_, primary_vid)| primary_vid == vid)
+            .unwrap_or(false);
+
+        sqlx::query(
+            "INSERT INTO route_variants
+             (agency_id, variant_id, route_id, direction_id, headsign, stop_count, trip_count, is_primary)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (agency_id, route_id, direction_id, variant_id) DO UPDATE SET
+               trip_count = EXCLUDED.trip_count,
+               is_primary = EXCLUDED.is_primary,
+               headsign   = EXCLUDED.headsign",
+        )
+        .bind(agency_id.as_str())
+        .bind(vid)
+        .bind(route_id)
+        .bind(direction_id)
+        .bind(headsign.as_deref())
+        .bind(stop_count)
+        .bind(trip_count)
+        .bind(is_primary)
+        .execute(&mut **tx)
+        .await?;
+
+        for (seq, sid) in stop_ids.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO route_variant_stops (agency_id, variant_id, stop_sequence, stop_id)
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (agency_id, variant_id, stop_sequence) DO NOTHING",
+            )
+            .bind(agency_id.as_str())
+            .bind(vid)
+            .bind(seq as i64)
+            .bind(sid)
+            .execute(&mut **tx)
+            .await?;
+        }
+
+        for trip_id in trip_ids {
+            sqlx::query(
+                "UPDATE trips SET variant_id = $1
+                 WHERE agency_id = $2 AND trip_id = $3",
+            )
+            .bind(vid)
+            .bind(agency_id.as_str())
+            .bind(trip_id)
+            .execute(&mut **tx)
+            .await?;
+        }
+    }
+
+    info!(
+        "Loaded {} route variants for agency {}",
+        pattern_map.len(),
+        agency_id
+    );
+    Ok(())
+}
+
+async fn get_stored_version(db: &Database, agency_id: &AgencyId) -> Result<Option<String>> {
+    let key = format!("gtfs_static_version_{agency_id}");
+    let row = sqlx::query!("SELECT value FROM feed_info WHERE key = $1", key,)
+        .fetch_optional(&db.pool)
+        .await?;
+    Ok(row.map(|r| r.value))
+}
+
+async fn get_last_download(db: &Database, agency_id: &AgencyId) -> Result<Option<String>> {
+    let key = format!("gtfs_static_last_download_{agency_id}");
+    let row = sqlx::query!("SELECT value FROM feed_info WHERE key = $1", key,)
+        .fetch_optional(&db.pool)
+        .await?;
+    Ok(row.map(|r| r.value))
+}
+
+async fn set_stored_version(db: &Database, agency_id: &AgencyId, version: &str) -> Result<()> {
+    let key = format!("gtfs_static_version_{agency_id}");
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query!(
+        "INSERT INTO feed_info (key, value, updated_at) VALUES ($1, $2, $3)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at",
+        key,
+        version,
+        now,
+    )
+    .execute(&db.pool)
+    .await?;
+    set_last_download(db, agency_id).await?;
+    Ok(())
+}
+
+async fn set_last_download(db: &Database, agency_id: &AgencyId) -> Result<()> {
+    let key = format!("gtfs_static_last_download_{agency_id}");
+    let now = chrono::Utc::now();
+    let today = now.date_naive().format("%Y-%m-%d").to_string();
+    let now = now.to_rfc3339();
+    sqlx::query!(
+        "INSERT INTO feed_info (key, value, updated_at) VALUES ($1, $2, $3)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at",
+        key,
+        today,
+        now,
+    )
+    .execute(&db.pool)
+    .await?;
     Ok(())
 }
 
@@ -752,7 +931,7 @@ mod tests {
             .unwrap();
         tx.commit().await.unwrap();
 
-        let rows: Vec<(String, bool, bool, bool, bool, bool, bool, bool)> = sqlx::query_as(
+        let rows: Vec<CalendarRow> = sqlx::query_as(
             "SELECT service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday
              FROM calendar WHERE agency_id = 'stm' ORDER BY service_id",
         )
@@ -838,178 +1017,4 @@ mod tests {
         );
         assert!(row.1, "monday should still be true");
     }
-}
-
-/// Compute a deterministic variant_id for a given stop sequence.
-/// Input: "{stop1_id},{stop2_id},..." — route and direction are intentionally
-/// excluded so the same physical pattern gets the same ID regardless of
-/// how the agency numbers or labels the route.
-fn variant_id_for(stop_ids: &[String]) -> String {
-    let input = stop_ids.join(",");
-    let digest = Sha256::digest(input.as_bytes());
-    hex::encode(&digest[..16])
-}
-
-/// Build and store route variants from already-loaded trips + scheduled_stops.
-/// Groups trips by their ordered stop sequence, assigns a deterministic variant_id,
-/// marks the variant with the most trips as primary, and links trips to their variant.
-pub(crate) async fn load_variants(
-    tx: &mut Tx<'_>,
-    agency_id: &AgencyId,
-    gtfs: &Gtfs,
-) -> Result<()> {
-    // Collect stop sequences per trip in memory (already loaded into DB, but gtfs struct is handy).
-    // key: (route_id, direction_id, stop_ids_csv) → (variant_id, trip_ids, headsign)
-    let mut pattern_map: HashMap<(String, i64, String), (String, Vec<String>, Option<String>)> =
-        HashMap::new();
-
-    for (trip_id, trip) in &gtfs.trips {
-        let direction_id = trip
-            .direction_id
-            .as_ref()
-            .map(direction_to_int)
-            .unwrap_or(0);
-
-        let stop_ids: Vec<String> = trip
-            .stop_times
-            .iter()
-            .map(|st| st.stop.id.clone())
-            .collect();
-        // stop_times from gtfs-structures are already ordered by stop_sequence
-        let stop_ids_csv = stop_ids.join(",");
-
-        let key = (trip.route_id.clone(), direction_id, stop_ids_csv.clone());
-        let vid = variant_id_for(&stop_ids);
-
-        let entry = pattern_map.entry(key).or_insert_with(|| {
-            let headsign = trip.trip_headsign.clone();
-            (vid.clone(), Vec::new(), headsign)
-        });
-        entry.1.push(trip_id.clone());
-    }
-
-    // Determine is_primary per (route_id, direction_id): variant with highest trip_count.
-    // Build: (route_id, direction_id) → max trip_count seen so far
-    let mut primary_map: HashMap<(String, i64), (usize, String)> = HashMap::new();
-    for ((route_id, direction_id, _), (vid, trip_ids, _)) in &pattern_map {
-        let count = trip_ids.len();
-        let entry = primary_map
-            .entry((route_id.clone(), *direction_id))
-            .or_insert((0, vid.clone()));
-        if count > entry.0 || (count == entry.0 && vid < &entry.1) {
-            *entry = (count, vid.clone());
-        }
-    }
-
-    for ((route_id, direction_id, stop_ids_csv), (vid, trip_ids, headsign)) in &pattern_map {
-        let stop_ids: Vec<&str> = stop_ids_csv.split(',').collect();
-        let stop_count = stop_ids.len() as i64;
-        let trip_count = trip_ids.len() as i64;
-        let is_primary = primary_map
-            .get(&(route_id.clone(), *direction_id))
-            .map(|(_, primary_vid)| primary_vid == vid)
-            .unwrap_or(false);
-
-        sqlx::query(
-            "INSERT INTO route_variants
-             (agency_id, variant_id, route_id, direction_id, headsign, stop_count, trip_count, is_primary)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-             ON CONFLICT (agency_id, route_id, direction_id, variant_id) DO UPDATE SET
-               trip_count = EXCLUDED.trip_count,
-               is_primary = EXCLUDED.is_primary,
-               headsign   = EXCLUDED.headsign",
-        )
-        .bind(agency_id.as_str())
-        .bind(vid)
-        .bind(route_id)
-        .bind(direction_id)
-        .bind(headsign.as_deref())
-        .bind(stop_count)
-        .bind(trip_count)
-        .bind(is_primary)
-        .execute(&mut **tx)
-        .await?;
-
-        for (seq, sid) in stop_ids.iter().enumerate() {
-            sqlx::query(
-                "INSERT INTO route_variant_stops (agency_id, variant_id, stop_sequence, stop_id)
-                 VALUES ($1, $2, $3, $4)
-                 ON CONFLICT (agency_id, variant_id, stop_sequence) DO NOTHING",
-            )
-            .bind(agency_id.as_str())
-            .bind(vid)
-            .bind(seq as i64)
-            .bind(sid)
-            .execute(&mut **tx)
-            .await?;
-        }
-
-        for trip_id in trip_ids {
-            sqlx::query(
-                "UPDATE trips SET variant_id = $1
-                 WHERE agency_id = $2 AND trip_id = $3",
-            )
-            .bind(vid)
-            .bind(agency_id.as_str())
-            .bind(trip_id)
-            .execute(&mut **tx)
-            .await?;
-        }
-    }
-
-    info!(
-        "Loaded {} route variants for agency {}",
-        pattern_map.len(),
-        agency_id
-    );
-    Ok(())
-}
-
-async fn get_stored_version(db: &Database, agency_id: &AgencyId) -> Result<Option<String>> {
-    let key = format!("gtfs_static_version_{agency_id}");
-    let row = sqlx::query!("SELECT value FROM feed_info WHERE key = $1", key,)
-        .fetch_optional(&db.pool)
-        .await?;
-    Ok(row.map(|r| r.value))
-}
-
-async fn get_last_download(db: &Database, agency_id: &AgencyId) -> Result<Option<String>> {
-    let key = format!("gtfs_static_last_download_{agency_id}");
-    let row = sqlx::query!("SELECT value FROM feed_info WHERE key = $1", key,)
-        .fetch_optional(&db.pool)
-        .await?;
-    Ok(row.map(|r| r.value))
-}
-
-async fn set_stored_version(db: &Database, agency_id: &AgencyId, version: &str) -> Result<()> {
-    let key = format!("gtfs_static_version_{agency_id}");
-    let now = chrono::Utc::now().to_rfc3339();
-    sqlx::query!(
-        "INSERT INTO feed_info (key, value, updated_at) VALUES ($1, $2, $3)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at",
-        key,
-        version,
-        now,
-    )
-    .execute(&db.pool)
-    .await?;
-    set_last_download(db, agency_id).await?;
-    Ok(())
-}
-
-async fn set_last_download(db: &Database, agency_id: &AgencyId) -> Result<()> {
-    let key = format!("gtfs_static_last_download_{agency_id}");
-    let now = chrono::Utc::now();
-    let today = now.date_naive().format("%Y-%m-%d").to_string();
-    let now = now.to_rfc3339();
-    sqlx::query!(
-        "INSERT INTO feed_info (key, value, updated_at) VALUES ($1, $2, $3)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at",
-        key,
-        today,
-        now,
-    )
-    .execute(&db.pool)
-    .await?;
-    Ok(())
 }


### PR DESCRIPTION
## Summary

- **`cargo clippy --all-targets --all-features -- -D warnings` now passes clean** — 9 distinct lint errors fixed across 5 files.
- All 218 existing tests still pass.

## Changes

### `mobilispect-core`

**`on_time_performance/trend.rs`**
- Added `sqlx::FromRow` to `DailyTrendPoint`. The `route_trend` query now decodes directly into the domain struct, removing the verbose `Vec<(String, Option<f64>, Option<f64>, Option<f64>)>` annotation and the manual mapping closure. (`type_complexity`)

**`speed_analysis/mod.rs`**
- Added private `SpeedPoint` and `DayBuckets` type aliases to simplify the `HashMap` local variable annotations in `build_direction_trends` and `build_variant_trends`. (`type_complexity`)

### `mobilispect-server`

**`web/handlers.rs`**
- Removed the bare `use serde_json;` import — redundant since `serde_json` is only used via qualified paths in this file. (`single_component_path_imports`)

### `mobilispect-worker`

**`feed_ingestion/realtime.rs`**
- Added `#![allow(clippy::enum_variant_names)]` inside the `proto` module wrapping the prost-generated protobuf include. The variant naming (`UnknownCongestionLevel`, `UnknownCause`, etc.) is mandated by the GTFS-RT spec and cannot be changed. (`enum_variant_names`)
- Removed two redundant `as i64` casts on `.time` fields that the proto definition already exposes as `i64`. (`unnecessary_cast`)

**`feed_ingestion/static_feed.rs`**
- Added `TripRow`, `PatternKey`, `PatternVal` type aliases (and `#[cfg(test)] CalendarRow`) to replace three over-complex local variable type annotations. (`type_complexity`)
- Renamed unused `date` binding in the skip-download guard to `_date`. (`unused_variables`)
- Moved `mod tests` to the end of the file. The private helpers `variant_id_for`, `load_variants`, `get_stored_version`, `get_last_download`, `set_stored_version`, and `set_last_download` were incorrectly placed *after* the test module. (`items_after_test_module`)

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean
- [x] `cargo nextest run` → 218/218 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)