### PR TITLE
test: add mutation-killing tests across core metrics modules

### DIFF
--- a/crates/core/src/ids.rs
+++ b/crates/core/src/ids.rs
@@ -164,6 +164,11 @@ mod tests {
     }
 
     #[test]
+    fn direction_id_as_i64_returns_nonzero_inner_value() {
+        assert_eq!(DirectionId(1).as_i64(), 1);
+    }
+
+    #[test]
     fn direction_id_display() {
         let id = DirectionId(1);
         assert_eq!(id.to_string(), "1");

--- a/crates/core/src/on_time_performance/route_summary.rs
+++ b/crates/core/src/on_time_performance/route_summary.rs
@@ -129,6 +129,78 @@ mod tests {
         assert_eq!(make_route_summary(None).badge_variant(), "neutral");
     }
 
+    #[test]
+    fn status_label_on_track_at_or_above_80() {
+        assert_eq!(make_route_summary(Some(80.0)).status_label(), "On track");
+        assert_eq!(make_route_summary(Some(95.0)).status_label(), "On track");
+    }
+
+    #[test]
+    fn status_label_degraded_between_60_and_80() {
+        assert_eq!(make_route_summary(Some(60.0)).status_label(), "Degraded");
+        assert_eq!(make_route_summary(Some(79.9)).status_label(), "Degraded");
+    }
+
+    #[test]
+    fn status_label_poor_below_60() {
+        assert_eq!(make_route_summary(Some(59.9)).status_label(), "Poor");
+        assert_eq!(make_route_summary(Some(0.0)).status_label(), "Poor");
+    }
+
+    #[test]
+    fn status_label_no_data_when_none() {
+        assert_eq!(make_route_summary(None).status_label(), "No data");
+    }
+
+    #[test]
+    fn on_time_display_formats_percentage() {
+        assert_eq!(make_route_summary(Some(87.0)).on_time_display(), "87%");
+    }
+
+    #[test]
+    fn on_time_display_dash_when_none() {
+        assert_eq!(make_route_summary(None).on_time_display(), "—");
+    }
+
+    fn make_route_summary_with_delay(delay: Option<f64>) -> RouteSummary {
+        RouteSummary {
+            agency_id: "stm".into(),
+            route_id: "R1".into(),
+            short_name: "1".into(),
+            long_name: "Route 1".into(),
+            avg_on_time_pct: None,
+            avg_delay_secs: delay,
+            trips_run: None,
+            trips_total: None,
+            days_measured: None,
+        }
+    }
+
+    #[test]
+    fn delay_display_formats_positive_delay() {
+        assert_eq!(
+            make_route_summary_with_delay(Some(120.0)).delay_display(),
+            "+120s"
+        );
+    }
+
+    #[test]
+    fn delay_display_formats_non_positive_delay() {
+        assert_eq!(
+            make_route_summary_with_delay(Some(-30.0)).delay_display(),
+            "-30s"
+        );
+        assert_eq!(
+            make_route_summary_with_delay(Some(0.0)).delay_display(),
+            "0s"
+        );
+    }
+
+    #[test]
+    fn delay_display_dash_when_none() {
+        assert_eq!(make_route_summary_with_delay(None).delay_display(), "—");
+    }
+
     #[tokio::test]
     async fn route_summary_filters_by_agency() {
         let td = test_utils::setup().await;

--- a/crates/core/src/on_time_performance/trend.rs
+++ b/crates/core/src/on_time_performance/trend.rs
@@ -260,4 +260,70 @@ mod tests {
         let pct = trend.speed_change_pct().unwrap();
         assert!((pct - 20.0).abs() < 0.1, "expected ~20%, got {pct}");
     }
+
+    fn make_trend_with_speeds(first: f64, last: f64) -> RouteTrend {
+        let days = (0..14)
+            .map(|i| DailyTrendPoint {
+                service_date: format!("2026-01-{:02}", i + 1),
+                on_time_pct: None,
+                avg_delay_secs: None,
+                actual_speed_mps: Some(if i < 7 { first } else { last }),
+            })
+            .collect();
+        RouteTrend {
+            route_id: "R1".into(),
+            short_name: "45".into(),
+            long_name: "PAPINEAU".into(),
+            days,
+        }
+    }
+
+    #[test]
+    fn speed_change_display_insufficient_data_when_too_few_days() {
+        let trend = RouteTrend {
+            route_id: "R1".into(),
+            short_name: "45".into(),
+            long_name: "PAPINEAU".into(),
+            days: vec![],
+        };
+        assert_eq!(trend.speed_change_display(), "Insufficient data");
+    }
+
+    #[test]
+    fn speed_change_display_faster_when_route_speeds_up() {
+        // 5.0 → 6.0 m/s = +20%
+        let trend = make_trend_with_speeds(5.0, 6.0);
+        assert_eq!(trend.speed_change_display(), "+20.0% faster");
+    }
+
+    #[test]
+    fn speed_change_display_slower_when_route_slows_down() {
+        // 6.0 → 5.0 m/s = -16.7%
+        let trend = make_trend_with_speeds(6.0, 5.0);
+        assert!(trend.speed_change_display().contains("slower"));
+    }
+
+    #[test]
+    fn speed_change_display_stable_when_no_significant_change() {
+        let trend = make_trend_with_speeds(5.0, 5.0);
+        assert_eq!(trend.speed_change_display(), "Stable");
+    }
+
+    #[test]
+    fn speed_change_class_decline_when_route_slows_down() {
+        let trend = make_trend_with_speeds(6.0, 5.0);
+        assert_eq!(trend.speed_change_class(), "decline");
+    }
+
+    #[test]
+    fn speed_change_class_improve_when_route_speeds_up() {
+        let trend = make_trend_with_speeds(5.0, 6.0);
+        assert_eq!(trend.speed_change_class(), "improve");
+    }
+
+    #[test]
+    fn speed_change_class_empty_when_stable() {
+        let trend = make_trend_with_speeds(5.0, 5.0);
+        assert_eq!(trend.speed_change_class(), "");
+    }
 }

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -358,6 +358,54 @@ ORDER BY
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::test_utils;
+
+    #[tokio::test]
+    async fn route_headways_returns_row_when_route_has_weekday_trips() {
+        let td = test_utils::setup().await;
+        let db = td.db;
+
+        sqlx::query("INSERT INTO routes VALUES ('stm', 'R1', '1', 'Route 1', 3)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO calendar VALUES ('stm', 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        // Two trips 30 minutes apart → 30-minute weekday headway
+        sqlx::query("INSERT INTO trips VALUES ('stm', 'T1', 'R1', 'WD', 0, null)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO trips VALUES ('stm', 'T2', 'R1', 'WD', 0, null)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops VALUES ('stm', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops VALUES ('stm', 'T2', 'S1', 1, '08:30:00', '08:30:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        let rows = route_headways(&db, None).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].route_id, "R1");
+        let headway = rows[0].weekday_headway_mins.unwrap();
+        assert!(
+            (headway - 30.0).abs() < 0.1,
+            "expected 30 min headway, got {headway}"
+        );
+    }
 
     #[test]
     fn headway_display_none() {
@@ -480,5 +528,55 @@ mod tests {
         let row = make_row(Some(8.0), None, None);
         assert_eq!(row.weekday_top_decile_display(), "5.0 min");
         assert_eq!(row.weekday_max_headway_display(), "30.0 min");
+    }
+
+    #[test]
+    fn weekday_display_formats_headway() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_display(), "8.0 min");
+    }
+
+    #[test]
+    fn saturday_display_formats_headway() {
+        let row = make_row(None, Some(15.0), None);
+        assert_eq!(row.saturday_display(), "15.0 min");
+    }
+
+    #[test]
+    fn sunday_display_formats_headway() {
+        let row = make_row(None, None, Some(20.0));
+        assert_eq!(row.sunday_display(), "20.0 min");
+    }
+
+    #[test]
+    fn saturday_top_decile_and_max_display() {
+        let row = make_row(None, Some(15.0), None);
+        assert_eq!(row.saturday_top_decile_display(), "10.0 min");
+        assert_eq!(row.saturday_max_headway_display(), "40.0 min");
+    }
+
+    #[test]
+    fn sunday_top_decile_and_max_display() {
+        let row = make_row(None, None, Some(20.0));
+        assert_eq!(row.sunday_top_decile_display(), "15.0 min");
+        assert_eq!(row.sunday_max_headway_display(), "50.0 min");
+    }
+
+    #[test]
+    fn weekday_badge_variant_delegates_to_headway() {
+        let row = make_row(Some(8.0), None, None);
+        assert_eq!(row.weekday_badge_variant(), "good");
+    }
+
+    #[test]
+    fn saturday_badge_variant_delegates_to_headway() {
+        let row = make_row(None, Some(15.0), None);
+        assert_eq!(row.saturday_badge_variant(), "mixed");
+    }
+
+    #[test]
+    fn sunday_badge_variant_delegates_to_headway() {
+        let row = make_row(None, None, Some(25.0));
+        assert_eq!(row.sunday_badge_variant(), "bad");
     }
 }

--- a/crates/core/src/speed_analysis/card.rs
+++ b/crates/core/src/speed_analysis/card.rs
@@ -516,6 +516,13 @@ mod tests {
     }
 
     #[test]
+    fn route_class_speed_range() {
+        assert_eq!(RouteClass::Local.speed_range(), "12-18 km/h");
+        assert_eq!(RouteClass::Rapid.speed_range(), "18-25 km/h");
+        assert_eq!(RouteClass::Express.speed_range(), ">25 km/h");
+    }
+
+    #[test]
     fn route_class_css_class() {
         assert_eq!(RouteClass::Local.css_class(), "local");
         assert_eq!(RouteClass::Rapid.css_class(), "rapid");

--- a/crates/core/src/speed_analysis/detail.rs
+++ b/crates/core/src/speed_analysis/detail.rs
@@ -388,4 +388,32 @@ mod tests {
         };
         assert_eq!(d.direction_badge_label(), "7 trips");
     }
+
+    fn make_direction(is_primary: bool) -> RouteSpeedDetailDirection {
+        RouteSpeedDetailDirection {
+            is_primary,
+            trip_count: 5,
+            avg_spacing_m: 400.0,
+            variant_id: VariantId::from(""),
+            direction_name: String::new(),
+            first_stop_name: String::new(),
+            spacings: vec![],
+            weekday_chart_id: String::new(),
+            saturday_chart_id: String::new(),
+            sunday_chart_id: String::new(),
+            weekday_json: String::new(),
+            saturday_json: String::new(),
+            sunday_json: String::new(),
+        }
+    }
+
+    #[test]
+    fn direction_badge_variant_primary_is_oxford() {
+        assert_eq!(make_direction(true).direction_badge_variant(), "oxford");
+    }
+
+    #[test]
+    fn direction_badge_variant_non_primary_is_neutral() {
+        assert_eq!(make_direction(false).direction_badge_variant(), "neutral");
+    }
 }

--- a/crates/core/src/speed_analysis/mod.rs
+++ b/crates/core/src/speed_analysis/mod.rs
@@ -1928,6 +1928,130 @@ mod tests {
     }
 
     #[test]
+    fn actual_speed_display_formats_kmh_one_decimal() {
+        // 10.0 m/s = 36.0 km/h
+        let s = make_summary(10.0, Some(10.0));
+        assert_eq!(s.actual_speed_display(), "36.0 km/h");
+    }
+
+    #[test]
+    fn actual_speed_display_dash_when_none() {
+        let s = make_summary(10.0, None);
+        assert_eq!(s.actual_speed_display(), "—");
+    }
+
+    #[test]
+    fn live_speed_display_formats_kmh_one_decimal() {
+        // 5.0 m/s = 18.0 km/h
+        let mut s = make_summary(10.0, None);
+        s.live_speed_mps = Some(5.0);
+        assert_eq!(s.live_speed_display(), "18.0 km/h");
+    }
+
+    #[test]
+    fn live_speed_display_dash_when_none() {
+        let s = make_summary(10.0, None);
+        assert_eq!(s.live_speed_display(), "—");
+    }
+
+    #[test]
+    fn direction_label_free_fn_outbound_inbound_unknown() {
+        assert_eq!(direction_label(DirectionId(0)), "Outbound");
+        assert_eq!(direction_label(DirectionId(1)), "Inbound");
+        assert_eq!(direction_label(DirectionId(99)), "Unknown");
+    }
+
+    #[test]
+    fn direction_label_instance_uses_last_stop_name_when_present() {
+        let mut s = make_summary(10.0, None);
+        s.last_stop_name = Some("Terminus Est".to_string());
+        assert_eq!(s.direction_label(), "Terminus Est");
+    }
+
+    #[test]
+    fn direction_label_instance_falls_back_to_direction_id_label() {
+        let s = make_summary(10.0, None); // direction_id = 0 → "Outbound"
+        assert_eq!(s.direction_label(), "Outbound");
+    }
+
+    #[test]
+    fn speed_class_slower_when_actual_lags_by_more_than_one_pct() {
+        // 10 m/s scheduled, 8 m/s actual → 20% deficit → "slower"
+        let s = make_summary(10.0, Some(8.0));
+        assert_eq!(s.speed_class(), "slower");
+    }
+
+    #[test]
+    fn speed_class_faster_when_actual_exceeds_by_more_than_one_pct() {
+        // 10 m/s scheduled, 11 m/s actual → -10% deficit → "faster"
+        let s = make_summary(10.0, Some(11.0));
+        assert_eq!(s.speed_class(), "faster");
+    }
+
+    #[test]
+    fn speed_class_onpace_within_threshold() {
+        // 10 m/s both → 0% deficit → "onpace"
+        let s = make_summary(10.0, Some(10.0));
+        assert_eq!(s.speed_class(), "onpace");
+    }
+
+    #[test]
+    fn speed_class_onpace_when_no_actual_data() {
+        let s = make_summary(10.0, None);
+        assert_eq!(s.speed_class(), "onpace");
+    }
+
+    fn make_stop_spacing(distance_m: f64, spacing_status: &str) -> StopSpacing {
+        StopSpacing {
+            to_stop_name: "Stop B".to_string(),
+            distance_m,
+            is_outlier: false,
+            width_px: 50,
+            spacing_status: spacing_status.to_string(),
+        }
+    }
+
+    #[test]
+    fn stop_spacing_distance_display_under_1km_shows_metres() {
+        assert_eq!(
+            make_stop_spacing(342.0, "in_range").distance_display(),
+            "342 m"
+        );
+    }
+
+    #[test]
+    fn stop_spacing_distance_display_at_or_over_1km_shows_km() {
+        assert_eq!(
+            make_stop_spacing(1200.0, "in_range").distance_display(),
+            "1.2 km"
+        );
+    }
+
+    #[test]
+    fn stop_spacing_status_class_below_is_slow() {
+        assert_eq!(
+            make_stop_spacing(200.0, "below").spacing_status_class(),
+            "slow"
+        );
+    }
+
+    #[test]
+    fn stop_spacing_status_class_above_is_outlier() {
+        assert_eq!(
+            make_stop_spacing(6000.0, "above").spacing_status_class(),
+            "outlier"
+        );
+    }
+
+    #[test]
+    fn stop_spacing_status_class_in_range_is_empty() {
+        assert_eq!(
+            make_stop_spacing(500.0, "in_range").spacing_status_class(),
+            ""
+        );
+    }
+
+    #[test]
     fn speed_deficit_pct_is_none_without_actual_data() {
         let s = make_summary(10.0, None);
         assert!(s.speed_deficit_pct().is_none());


### PR DESCRIPTION
## Summary

- Ran `cargo mutants` across the full `mobilispect-core` crate and identified 29 surviving mutants — all caused by methods that existed but had no direct test coverage
- Added ~400 lines of new tests across 7 files to kill every surviving mutant
- All 239 tests pass

## Files changed

| File | What was added |
|------|---------------|
| `ids.rs` | Test for non-zero `DirectionId::as_i64()` |
| `on_time_performance/route_summary.rs` | 8 tests for `status_label`, `on_time_display`, `delay_display` |
| `on_time_performance/trend.rs` | 7 tests for `speed_change_display` and `speed_change_class` |
| `service_frequency/mod.rs` | 8 instance-delegate tests + integration test for `route_headways` |
| `speed_analysis/card.rs` | Test for `RouteClass::speed_range()` |
| `speed_analysis/detail.rs` | 2 tests for `direction_badge_variant` |
| `speed_analysis/mod.rs` | 16 tests for free `direction_label`, display formatters, `speed_class`, `StopSpacing` methods |

## Test plan

- [x] `cargo nextest run --profile ci` — 239 tests, 0 failures
- [x] `cargo mutants --timeout 300 --jobs 1 --test-tool nextest -- --profile ci` — 0 surviving mutants in covered files

🤖 Generated with [Claude Code](https://claude.com/claude-code)