### PR TITLE
chore(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -29,7 +29,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
@@ -43,7 +43,7 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,9 +51,9 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -77,11 +77,15 @@ jobs:
         # If taiki-e/install-action fails to find a binary,
         # replace with: cargo install cargo-mutants --locked && cargo install cargo-nextest --locked
       - name: Compute PR diff
-        run: git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git diff origin/"$BASE_REF"...HEAD > /tmp/pr.diff
       - name: Check for Rust changes
         id: rust_changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if git diff origin/${{ github.base_ref }}...HEAD --name-only | grep -q '\.rs$'; then
+          if git diff origin/"$BASE_REF"...HEAD --name-only | grep -q '\.rs$'; then
             echo "has_rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_rust=false" >> "$GITHUB_OUTPUT"
@@ -91,7 +95,7 @@ jobs:
         run: cargo mutants --in-diff /tmp/pr.diff --timeout 300 --jobs 1 --test-tool nextest -- --profile ci
       - name: Upload mutants output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutants-out
           path: mutants.out/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Install Railway CLI


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6
- `docker/setup-buildx-action` v3 → v4
- `docker/build-push-action` v6 → v7
- `actions/upload-artifact` v4 → v7
- `Swatinem/rust-cache`, `taiki-e/install-action`, `rustsec/audit-check` — all already on latest major (v2), no change needed

## Security fix

`${{ github.base_ref }}` was interpolated directly into two `run:` commands in the `mutants` job. While branch names are constrained, this is still an injection risk per GitHub's hardening guide. Both occurrences now use an `env:` var (`BASE_REF`) and quote it in the shell.

## Test plan

- [ ] CI runs green on this PR (lint, test, audit, docker-build jobs all exercise the updated actions)
- [ ] Mutation testing job skipped on push (PR-only), will run on any follow-up PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)