### PR TITLE
fix: eliminate speed_page 500 errors (stale connections + expensive CTE)

### DIFF
--- a/crates/core/migrations/010_route_speed_last_stop_name.sql
+++ b/crates/core/migrations/010_route_speed_last_stop_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE route_speed ADD COLUMN last_stop_name TEXT;

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use sqlx::PgPool;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use std::str::FromStr;
+use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct Database {
@@ -13,6 +14,8 @@ impl Database {
         let options = PgConnectOptions::from_str(database_url)?;
         let pool = PgPoolOptions::new()
             .max_connections(5)
+            .idle_timeout(Duration::from_secs(300))
+            .test_before_acquire(true)
             .connect_with(options)
             .await?;
         Ok(Self { pool })

--- a/crates/core/src/speed_analysis/mod.rs
+++ b/crates/core/src/speed_analysis/mod.rs
@@ -917,7 +917,7 @@ pub async fn route_speed_summary(
                rs.trip_count,
                live.avg_live_speed as live_speed_mps,
                hist.avg_actual_speed as actual_speed_mps,
-               lsn.stop_name as last_stop_name
+               rs.last_stop_name
              FROM route_speed rs
              JOIN routes r ON rs.agency_id = r.agency_id AND rs.route_id = r.route_id
              LEFT JOIN (
@@ -934,23 +934,6 @@ pub async fn route_speed_summary(
                WHERE service_date >= (CURRENT_DATE - INTERVAL '7 days')::TEXT
                GROUP BY agency_id, route_id, direction_id
              ) hist ON hist.agency_id = rs.agency_id AND hist.route_id = rs.route_id AND hist.direction_id = rs.direction_id
-             LEFT JOIN (
-               SELECT DISTINCT ON (t.agency_id, t.route_id, COALESCE(t.direction_id, 0))
-                 t.agency_id, t.route_id, COALESCE(t.direction_id, 0) AS direction_id,
-                 s.stop_name
-               FROM trips t
-               JOIN (
-                 SELECT agency_id, trip_id, stop_id
-                 FROM (
-                   SELECT agency_id, trip_id, stop_id,
-                          ROW_NUMBER() OVER (PARTITION BY agency_id, trip_id ORDER BY stop_sequence DESC) AS rn
-                   FROM scheduled_stops
-                 ) ranked
-                 WHERE rn = 1
-               ) last_ss ON last_ss.agency_id = t.agency_id AND last_ss.trip_id = t.trip_id
-               JOIN stops s ON s.agency_id = t.agency_id AND s.stop_id = last_ss.stop_id
-               ORDER BY t.agency_id, t.route_id, COALESCE(t.direction_id, 0)
-             ) lsn ON lsn.agency_id = rs.agency_id AND lsn.route_id = rs.route_id AND lsn.direction_id = rs.direction_id
              ORDER BY rs.agency_id, CASE WHEN r.short_name ~ '^[0-9]+$' THEN r.short_name::INTEGER ELSE NULL END NULLS LAST, r.short_name, rs.direction_id",
         )
         .fetch_all(&db.pool)
@@ -967,7 +950,7 @@ pub async fn route_speed_summary(
                rs.trip_count,
                live.avg_live_speed as live_speed_mps,
                hist.avg_actual_speed as actual_speed_mps,
-               lsn.stop_name as last_stop_name
+               rs.last_stop_name
              FROM route_speed rs
              JOIN routes r ON rs.agency_id = r.agency_id AND rs.route_id = r.route_id
              LEFT JOIN (
@@ -984,23 +967,6 @@ pub async fn route_speed_summary(
                WHERE service_date >= (CURRENT_DATE - INTERVAL '7 days')::TEXT
                GROUP BY agency_id, route_id, direction_id
              ) hist ON hist.agency_id = rs.agency_id AND hist.route_id = rs.route_id AND hist.direction_id = rs.direction_id
-             LEFT JOIN (
-               SELECT DISTINCT ON (t.agency_id, t.route_id, COALESCE(t.direction_id, 0))
-                 t.agency_id, t.route_id, COALESCE(t.direction_id, 0) AS direction_id,
-                 s.stop_name
-               FROM trips t
-               JOIN (
-                 SELECT agency_id, trip_id, stop_id
-                 FROM (
-                   SELECT agency_id, trip_id, stop_id,
-                          ROW_NUMBER() OVER (PARTITION BY agency_id, trip_id ORDER BY stop_sequence DESC) AS rn
-                   FROM scheduled_stops
-                 ) ranked
-                 WHERE rn = 1
-               ) last_ss ON last_ss.agency_id = t.agency_id AND last_ss.trip_id = t.trip_id
-               JOIN stops s ON s.agency_id = t.agency_id AND s.stop_id = last_ss.stop_id
-               ORDER BY t.agency_id, t.route_id, COALESCE(t.direction_id, 0)
-             ) lsn ON lsn.agency_id = rs.agency_id AND lsn.route_id = rs.route_id AND lsn.direction_id = rs.direction_id
              WHERE rs.agency_id = $1
              ORDER BY rs.agency_id, CASE WHEN r.short_name ~ '^[0-9]+$' THEN r.short_name::INTEGER ELSE NULL END NULLS LAST, r.short_name, rs.direction_id",
         )
@@ -1159,23 +1125,6 @@ pub async fn route_speed_by_day_type(
             WHERE service_date::date >= CURRENT_DATE - INTERVAL '28 days'
               AND actual_speed_mps IS NOT NULL
             GROUP BY agency_id, route_id, direction_id
-        ),
-        last_stop_per_route_dir AS (
-            SELECT DISTINCT ON (t.agency_id, t.route_id, COALESCE(t.direction_id, 0))
-              t.agency_id, t.route_id, COALESCE(t.direction_id, 0) AS direction_id,
-              s.stop_name
-            FROM trips t
-            JOIN (
-              SELECT agency_id, trip_id, stop_id
-              FROM (
-                SELECT agency_id, trip_id, stop_id,
-                       ROW_NUMBER() OVER (PARTITION BY agency_id, trip_id ORDER BY stop_sequence DESC) AS rn
-                FROM scheduled_stops
-              ) ranked
-              WHERE rn = 1
-            ) last_ss ON last_ss.agency_id = t.agency_id AND last_ss.trip_id = t.trip_id
-            JOIN stops s ON s.agency_id = t.agency_id AND s.stop_id = last_ss.stop_id
-            ORDER BY t.agency_id, t.route_id, COALESCE(t.direction_id, 0)
         )
         SELECT
           rs.agency_id,
@@ -1190,7 +1139,7 @@ pub async fn route_speed_by_day_type(
           act.actual_saturday_speed_mps,
           act.actual_sunday_speed_mps,
           act.avg_dwell_secs,
-          lsn.stop_name AS last_stop_name,
+          rs.last_stop_name,
           rs.avg_stop_spacing_m
         FROM route_speed rs
         JOIN routes r ON r.agency_id = rs.agency_id AND r.route_id = rs.route_id
@@ -1206,9 +1155,6 @@ pub async fn route_speed_by_day_type(
         LEFT JOIN actual_by_day_type act
           ON act.agency_id = rs.agency_id AND act.route_id = rs.route_id
          AND act.direction_id = rs.direction_id
-        LEFT JOIN last_stop_per_route_dir lsn
-          ON lsn.agency_id = rs.agency_id AND lsn.route_id = rs.route_id
-         AND lsn.direction_id = rs.direction_id
         ";
 
     let order_sql = "ORDER BY rs.agency_id,
@@ -2506,28 +2452,9 @@ mod tests {
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','First Stop',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Last Stop',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0', 'R1', 0, 8.0, 3, '2026-01-01T00:00:00Z')",
+            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at, last_stop_name)
+             VALUES ('0', 'R1', 0, 8.0, 3, '2026-01-01T00:00:00Z', 'Last Stop')",
         )
         .execute(&db.pool)
         .await
@@ -2539,7 +2466,7 @@ mod tests {
         assert_eq!(
             summary[0].last_stop_name.as_deref(),
             Some("Last Stop"),
-            "expected last stop name to be the terminal stop"
+            "expected last stop name from persisted route_speed column"
         );
     }
 
@@ -2552,30 +2479,10 @@ mod tests {
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','First Stop',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Last Stop',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 8.0, 1111.0, 1, '2026-01-01T00:00:00Z')",
+             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at, last_stop_name)
+             VALUES ('0', 'R1', 0, 8.0, 1111.0, 1, '2026-01-01T00:00:00Z', 'Last Stop')",
         )
         .execute(&db.pool)
         .await
@@ -2587,7 +2494,7 @@ mod tests {
         assert_eq!(
             rows[0].last_stop_name.as_deref(),
             Some("Last Stop"),
-            "expected last stop name to be the terminal stop"
+            "expected last stop name from persisted route_speed column"
         );
     }
 

--- a/crates/core/src/speed_analysis/mod.rs
+++ b/crates/core/src/speed_analysis/mod.rs
@@ -576,8 +576,8 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
 
         // Derive avg_stop_spacing_m from the primary variant's canonical stop list,
         // not from averaging across all trips (which conflates short-turns and full routes).
-        let primary_stops: Vec<(f64, f64)> = sqlx::query_as(
-            "SELECT s.stop_lat, s.stop_lon
+        let primary_stops: Vec<(f64, f64, String)> = sqlx::query_as(
+            "SELECT s.stop_lat, s.stop_lon, s.stop_name
              FROM route_variant_stops rvs
              JOIN route_variants rv ON rv.agency_id = rvs.agency_id AND rv.variant_id = rvs.variant_id
              JOIN stops s ON s.agency_id = rvs.agency_id AND s.stop_id = rvs.stop_id
@@ -589,6 +589,8 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
         .bind(direction_id)
         .fetch_all(&db.pool)
         .await?;
+
+        let last_stop_name: Option<String> = primary_stops.last().map(|s| s.2.clone());
 
         let avg_stop_spacing_m = if primary_stops.len() >= 2 {
             let spacings: Vec<f64> = primary_stops
@@ -610,13 +612,14 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
 
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at, last_stop_name)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
              ON CONFLICT (agency_id, route_id, direction_id) DO UPDATE SET
                scheduled_speed_mps = EXCLUDED.scheduled_speed_mps,
                avg_stop_spacing_m = EXCLUDED.avg_stop_spacing_m,
                trip_count = EXCLUDED.trip_count,
-               computed_at = EXCLUDED.computed_at",
+               computed_at = EXCLUDED.computed_at,
+               last_stop_name = EXCLUDED.last_stop_name",
         )
         .bind(&agency_id)
         .bind(route_id)
@@ -625,6 +628,7 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
         .bind(avg_stop_spacing_m)
         .bind(trip_count)
         .bind(&now)
+        .bind(last_stop_name.as_deref())
         .execute(&db.pool)
         .await?;
     }
@@ -3698,5 +3702,63 @@ mod tests {
         let td = test_utils::setup().await;
         let agency = test_agency();
         on_realtime_polled(&td.db, &agency).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn compute_route_speed_stores_last_stop_name() {
+        let td = test_utils::setup().await;
+        let db = td.db;
+
+        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO stops VALUES ('0','S1','First Stop',45.50,-73.50)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO stops VALUES ('0','S2','Last Stop',45.51,-73.50)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES ('0', 'VAR1', 'R1', 0, 2, 1, true)",
+        ).execute(&db.pool).await.unwrap();
+        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        compute_route_speed(&db, &test_agency()).await.unwrap();
+
+        let last_stop_name: Option<String> = sqlx::query_scalar(
+            "SELECT last_stop_name FROM route_speed WHERE agency_id = '0' AND route_id = 'R1' AND direction_id = 0",
+        )
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            last_stop_name.as_deref(),
+            Some("Last Stop"),
+            "compute_route_speed should persist last_stop_name from the primary variant"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Production `speed_page` was returning 500 Internal Server Errors with two distinct failure modes logged:

- **`pool timed out while waiting for an open connection`** — a `ROW_NUMBER()` window scan over all `scheduled_stops` ran on every page load, causing queries to take 16–30 s and exhaust the 5-connection pool under any concurrency.
- **`Connection reset by peer`** — after periods of inactivity, Railway's Postgres server closes idle connections; the pool didn't know, so it handed out dead connections.

## Changes

### Fix 1 — Connection pool (`crates/core/src/db/mod.rs`)
- `idle_timeout(300s)`: recycles connections idle > 5 min, giving a safe margin before Railway's Postgres closes them.
- `test_before_acquire(true)`: pings each connection before use; drops dead ones silently instead of propagating the OS error to the handler.

### Fix 2 — Pre-compute `last_stop_name` (`crates/core/migrations/010_…`, `crates/core/src/speed_analysis/mod.rs`)
- New nullable `last_stop_name TEXT` column on `route_speed`.
- `compute_route_speed` (runs at GTFS static load time) now stores the primary variant's terminal stop name into that column — zero extra DB round-trips at query time.
- `route_speed_by_day_type` and `route_speed_summary` (both arms) now read `rs.last_stop_name` directly, removing the `last_stop_per_route_dir` CTE / subquery that previously did a full `ROW_NUMBER() OVER (… scheduled_stops)` scan on every page load.

## Test plan

- [ ] All 270 existing tests pass (`cargo nextest run`)
- [ ] New integration test `compute_route_speed_stores_last_stop_name` verifies the column is populated at ingest time
- [ ] Existing tests `route_speed_by_day_type_includes_last_stop_name` and `route_speed_summary_includes_last_stop_name` updated to insert `last_stop_name` directly (no longer rely on the removed CTE)
- [ ] After deploy: `speed_page` should load without 500 errors; Railway logs should show no more `pool timed out` or `Connection reset by peer` errors

## Reviewer notes

- The `last_stop_name` column will be `NULL` for existing `route_speed` rows until `compute_route_speed` runs again (triggered by the next GTFS static load). The queries handle `NULL` correctly — `last_stop_name` was already `Option<String>` in the Rust struct.
- Services were restarted manually on Railway to clear the current error state while this fix is prepared for deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)