### PR TITLE
Add schedule detail page with hourly frequency plot per day type

### DIFF
--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -4,6 +4,143 @@ use serde::Serialize;
 use crate::db::Database;
 use crate::ids::{FeedId, RouteId};
 
+#[derive(Debug, Serialize)]
+pub struct HourBin {
+    pub hour: i32,
+    pub trip_count: i32,
+}
+
+pub struct RouteHourlyFrequency {
+    pub short_name: String,
+    pub long_name: String,
+    pub weekday_bins: Vec<HourBin>,
+    pub saturday_bins: Vec<HourBin>,
+    pub sunday_bins: Vec<HourBin>,
+}
+
+impl RouteHourlyFrequency {
+    pub fn has_weekday(&self) -> bool {
+        !self.weekday_bins.is_empty()
+    }
+
+    pub fn has_saturday(&self) -> bool {
+        !self.saturday_bins.is_empty()
+    }
+
+    pub fn has_sunday(&self) -> bool {
+        !self.sunday_bins.is_empty()
+    }
+
+    pub fn weekday_json(&self) -> String {
+        serde_json::to_string(&self.weekday_bins).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    pub fn saturday_json(&self) -> String {
+        serde_json::to_string(&self.saturday_bins).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    pub fn sunday_json(&self) -> String {
+        serde_json::to_string(&self.sunday_bins).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct HourlyRow {
+    day_type: Option<String>,
+    hour: i32,
+    trip_count: i32,
+}
+
+pub async fn route_hourly_frequency(
+    db: &Database,
+    feed_id: FeedId,
+    route_id: &RouteId,
+) -> Result<Option<RouteHourlyFrequency>> {
+    let route_info = sqlx::query!(
+        "SELECT short_name, long_name FROM routes WHERE onestop_id = $1",
+        route_id.as_str()
+    )
+    .fetch_optional(&db.pool)
+    .await?;
+
+    let (short_name, long_name) = match route_info {
+        Some(r) => (r.short_name, r.long_name),
+        None => return Ok(None),
+    };
+
+    let sql = "WITH trip_first AS (
+    SELECT
+        t.trip_id,
+        (svc.monday OR svc.tuesday OR svc.wednesday
+         OR svc.thursday OR svc.friday) AS is_weekday,
+        svc.saturday                     AS is_saturday,
+        svc.sunday                       AS is_sunday,
+        MIN(
+            SPLIT_PART(ss.departure_time, ':', 1)::INT * 3600
+          + SPLIT_PART(ss.departure_time, ':', 2)::INT * 60
+          + SPLIT_PART(ss.departure_time, ':', 3)::INT
+        ) AS departure_secs
+    FROM trips t
+    JOIN route_variants rv
+      ON rv.feed_id = t.feed_id AND rv.variant_id = t.variant_id
+    JOIN services svc
+      ON svc.feed_id = t.feed_id AND svc.service_id = t.service_id
+    JOIN scheduled_stops ss
+      ON ss.feed_id = t.feed_id AND ss.trip_id = t.trip_id
+    WHERE t.feed_id = $1
+      AND rv.route_id = $2
+      AND (svc.monday OR svc.tuesday OR svc.wednesday OR svc.thursday
+           OR svc.friday OR svc.saturday OR svc.sunday)
+    GROUP BY t.trip_id,
+             svc.monday, svc.tuesday, svc.wednesday,
+             svc.thursday, svc.friday, svc.saturday, svc.sunday
+),
+hourly AS (
+    SELECT
+        CASE
+            WHEN is_weekday THEN 'weekday'
+            WHEN is_saturday THEN 'saturday'
+            WHEN is_sunday   THEN 'sunday'
+        END AS day_type,
+        departure_secs / 3600 AS hour,
+        COUNT(*)::INT          AS trip_count
+    FROM trip_first
+    GROUP BY day_type, hour
+)
+SELECT day_type, hour::INT AS hour, trip_count
+FROM hourly
+WHERE day_type IS NOT NULL
+ORDER BY day_type, hour";
+
+    let rows: Vec<HourlyRow> = sqlx::query_as(sql)
+        .bind(feed_id.as_i64())
+        .bind(route_id.as_str())
+        .fetch_all(&db.pool)
+        .await?;
+
+    let mut weekday_bins = Vec::new();
+    let mut saturday_bins = Vec::new();
+    let mut sunday_bins = Vec::new();
+
+    for row in rows {
+        let bin = HourBin { hour: row.hour, trip_count: row.trip_count };
+        match row.day_type.as_deref() {
+            Some("weekday") => weekday_bins.push(bin),
+            Some("saturday") => saturday_bins.push(bin),
+            Some("sunday") => sunday_bins.push(bin),
+            _ => {}
+        }
+    }
+
+    Ok(Some(RouteHourlyFrequency {
+        short_name,
+        long_name,
+        weekday_bins,
+        saturday_bins,
+        sunday_bins,
+    }))
+}
+
 #[derive(Debug, sqlx::FromRow, Serialize)]
 pub struct RouteHeadwayRow {
     pub feed_id: FeedId,
@@ -608,5 +745,154 @@ mod tests {
     fn sunday_badge_variant_delegates_to_headway() {
         let row = make_row(None, None, Some(25.0));
         assert_eq!(row.sunday_badge_variant(), "bad");
+    }
+
+    async fn setup_route(
+        db: &crate::db::Database,
+        feed_id: i64,
+        route_id: &str,
+        short_name: &str,
+        long_name: &str,
+    ) {
+        sqlx::query(&format!(
+            "INSERT INTO feeds (id, gtfs_static_url) VALUES ({feed_id}, 'http://test')"
+        ))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(&format!(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('{route_id}', 'agency', '{short_name}', '{long_name}', 3)"
+        ))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.5, -73.5)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_service(db: &crate::db::Database, feed_id: i64, service_id: &str, weekday: bool, saturday: bool, sunday: bool) {
+        sqlx::query(&format!(
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ({feed_id}, '{service_id}', {weekday}, {weekday}, {weekday}, {weekday}, {weekday}, {saturday}, {sunday})"
+        ))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_trip_at_hour(
+        db: &crate::db::Database,
+        feed_id: i64,
+        trip_id: &str,
+        service_id: &str,
+        variant_id: &str,
+        hour: u32,
+    ) {
+        sqlx::query(&format!(
+            "INSERT INTO trips (feed_id, trip_id, service_id, variant_id) VALUES ({feed_id}, '{trip_id}', '{service_id}', '{variant_id}')"
+        ))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(&format!(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) VALUES ({feed_id}, '{trip_id}', 'S1', 1, '{hour:02}:00:00', '{hour:02}:00:00')"
+        ))
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn route_hourly_frequency_returns_none_for_unknown_route() {
+        let td = test_utils::setup().await;
+        let result = route_hourly_frequency(
+            &td.db,
+            FeedId::from(1i64),
+            &RouteId::from("r-unknown"),
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn route_hourly_frequency_groups_weekday_trips_by_hour() {
+        let td = test_utils::setup().await;
+        let db = &td.db;
+        setup_route(db, 1, "r-test-R1", "1", "Route 1").await;
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'V1', 'r-test-R1', 0, 1, 3, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        insert_service(db, 1, "WD", true, false, false).await;
+        insert_trip_at_hour(db, 1, "T1", "WD", "V1", 8).await;
+        insert_trip_at_hour(db, 1, "T2", "WD", "V1", 8).await;
+        insert_trip_at_hour(db, 1, "T3", "WD", "V1", 9).await;
+
+        let freq = route_hourly_frequency(db, FeedId::from(1i64), &RouteId::from("r-test-R1"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(freq.short_name, "1");
+        assert!(freq.has_weekday());
+        assert!(!freq.has_saturday());
+        assert!(!freq.has_sunday());
+        assert_eq!(freq.weekday_bins.len(), 2);
+        assert_eq!(freq.weekday_bins[0].hour, 8);
+        assert_eq!(freq.weekday_bins[0].trip_count, 2);
+        assert_eq!(freq.weekday_bins[1].hour, 9);
+        assert_eq!(freq.weekday_bins[1].trip_count, 1);
+    }
+
+    #[tokio::test]
+    async fn route_hourly_frequency_separates_saturday_and_sunday() {
+        let td = test_utils::setup().await;
+        let db = &td.db;
+        setup_route(db, 1, "r-test-R2", "2", "Route 2").await;
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'V2', 'r-test-R2', 0, 1, 2, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        insert_service(db, 1, "SAT", false, true, false).await;
+        insert_service(db, 1, "SUN", false, false, true).await;
+        insert_trip_at_hour(db, 1, "T1", "SAT", "V2", 10).await;
+        insert_trip_at_hour(db, 1, "T2", "SUN", "V2", 11).await;
+
+        let freq = route_hourly_frequency(db, FeedId::from(1i64), &RouteId::from("r-test-R2"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(!freq.has_weekday());
+        assert!(freq.has_saturday());
+        assert!(freq.has_sunday());
+        assert_eq!(freq.saturday_bins[0].hour, 10);
+        assert_eq!(freq.saturday_bins[0].trip_count, 1);
+        assert_eq!(freq.sunday_bins[0].hour, 11);
+        assert_eq!(freq.sunday_bins[0].trip_count, 1);
+    }
+
+    #[test]
+    fn route_hourly_frequency_json_methods_serialize_bins() {
+        let freq = RouteHourlyFrequency {
+            short_name: "1".to_string(),
+            long_name: "Route 1".to_string(),
+            weekday_bins: vec![HourBin { hour: 8, trip_count: 3 }],
+            saturday_bins: vec![],
+            sunday_bins: vec![],
+        };
+        let json = freq.weekday_json();
+        assert!(json.contains("\"hour\":8"));
+        assert!(json.contains("\"trip_count\":3"));
+        assert_eq!(freq.saturday_json(), "[]");
+        assert_eq!(freq.sunday_json(), "[]");
     }
 }

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use crate::web::AppState;
 use mobilispect_core::ids::{FeedId, RouteId};
 use mobilispect_core::on_time_performance::{RouteSummary, RouteTrend, route_summary, route_trend};
-use mobilispect_core::service_frequency::{RouteHeadwayRow, route_headways};
+use mobilispect_core::service_frequency::{RouteHeadwayRow, RouteHourlyFrequency, route_headways, route_hourly_frequency};
 use mobilispect_core::speed_analysis::{
     RouteClass, RouteSpeedCard, RouteSpeedDetailDirection, RouteSpeedSummary, assign_indices,
     build_detail_directions, build_speed_cards, classify_by_spacing, fetch_route_info,
@@ -450,6 +450,61 @@ pub async fn frequency_page(
                 )
                     .into_response()
             }
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(path = "pages/schedule_detail.html")]
+struct ScheduleDetailTemplate {
+    region_name: String,
+    feed_id: FeedId,
+    frequency: RouteHourlyFrequency,
+}
+
+pub async fn schedule_detail(
+    State(state): State<AppState>,
+    axum::extract::Path((feed_id_str, route_id_str)): axum::extract::Path<(String, String)>,
+) -> axum::response::Response {
+    let feed_id = feed_id_str
+        .parse::<i64>()
+        .map(FeedId::from)
+        .unwrap_or_else(|_| FeedId::from(0i64));
+    let route_id = RouteId::from(route_id_str);
+
+    let frequency = match route_hourly_frequency(&state.db, feed_id, &route_id).await {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Html("<h1>Not Found</h1>".to_string()),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "DB error in schedule_detail");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<h1>Internal Server Error</h1>".to_string()),
+            )
+                .into_response();
+        }
+    };
+
+    let tmpl = ScheduleDetailTemplate {
+        region_name: state.config.region.name.clone(),
+        feed_id,
+        frequency,
+    };
+    match tmpl.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Template render error in schedule_detail");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<h1>Internal Server Error</h1>".to_string()),
+            )
+                .into_response()
         }
     }
 }

--- a/crates/server/src/web/mod.rs
+++ b/crates/server/src/web/mod.rs
@@ -20,6 +20,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/speed", get(handlers::speed_page))
         .route("/schedule", get(handlers::frequency_page))
         .route("/frequency", get(handlers::frequency_page))
+        .route(
+            "/schedule/:feed_id/:route_id",
+            get(handlers::schedule_detail),
+        )
         // /speed route registered BEFORE bare :route_id to avoid shadowing
         .route(
             "/routes/:agency_id/:route_id/speed",

--- a/crates/server/templates/pages/schedule_detail.html
+++ b/crates/server/templates/pages/schedule_detail.html
@@ -1,0 +1,159 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}Mobilispect — Route {{ frequency.short_name }} Schedule{% endblock %}
+{% block region_name %}{{ region_name }}{% endblock %}
+{% block nav_frequency %}active{% endblock %}
+
+{% block extra_head %}
+<style>
+.freq-plot-section {
+  margin-bottom: 2rem;
+}
+.freq-plot-label {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 0.75rem;
+}
+.freq-plot-wrap {
+  background: var(--surface-muted);
+  border-radius: 8px;
+  padding: 1rem 1rem 0.5rem;
+  overflow-x: auto;
+}
+.freq-plot {
+  min-width: 100%;
+}
+.freq-plot svg {
+  display: block;
+  overflow: visible;
+}
+.no-data {
+  color: var(--ink-400);
+  font-size: 0.82rem;
+  font-style: italic;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Route {{ frequency.short_name }} — {{ frequency.long_name }}</h1>
+      <p class="page-subtitle">Hourly trip frequency by day type</p>
+    </div>
+    <a class="chip" href="/schedule?agency={{ feed_id }}">← Back to schedule overview</a>
+  </div>
+
+  {% if !frequency.has_weekday() && !frequency.has_saturday() && !frequency.has_sunday() %}
+  <p class="no-data">No schedule data available for this route.</p>
+  {% else %}
+
+  {% if frequency.has_weekday() %}
+  <div class="card freq-plot-section" style="padding:1.25rem 1.5rem;">
+    <div class="freq-plot-label">Weekday</div>
+    <div class="freq-plot-wrap">
+      <div class="freq-plot" data-bins="{{ frequency.weekday_json()|e }}" data-color="oxford"></div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if frequency.has_saturday() %}
+  <div class="card freq-plot-section" style="padding:1.25rem 1.5rem;">
+    <div class="freq-plot-label">Saturday</div>
+    <div class="freq-plot-wrap">
+      <div class="freq-plot" data-bins="{{ frequency.saturday_json()|e }}" data-color="oxford"></div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if frequency.has_sunday() %}
+  <div class="card freq-plot-section" style="padding:1.25rem 1.5rem;">
+    <div class="freq-plot-label">Sunday</div>
+    <div class="freq-plot-wrap">
+      <div class="freq-plot" data-bins="{{ frequency.sunday_json()|e }}" data-color="oxford"></div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+  const BAR_W = 18;
+  const BAR_GAP = 3;
+  const CHART_H = 100;
+  const AXIS_H = 20;
+  const PAD_TOP = 8;
+
+  function drawPlot(el) {
+    const bins = JSON.parse(el.dataset.bins || '[]');
+    if (!bins.length) return;
+
+    const style = getComputedStyle(document.documentElement);
+    const barColor = style.getPropertyValue('--link-blue').trim() || '#1D4E89';
+    const gridColor = style.getPropertyValue('--line-soft').trim() || '#ECEAE4';
+    const labelColor = style.getPropertyValue('--ink-400').trim() || '#A8A49B';
+
+    const maxCount = Math.max(...bins.map(b => b.trip_count), 1);
+    const minHour = bins[0].hour;
+    const maxHour = bins[bins.length - 1].hour;
+    const numHours = maxHour - minHour + 1;
+    const totalW = numHours * (BAR_W + BAR_GAP);
+    const svgH = CHART_H + AXIS_H + PAD_TOP;
+
+    // Index bins by hour for O(1) lookup
+    const byHour = {};
+    bins.forEach(b => { byHour[b.hour] = b.trip_count; });
+
+    let bars = '';
+    let labels = '';
+    let gridLines = '';
+
+    // Horizontal guide lines at 25%, 50%, 75%, 100%
+    [0.25, 0.5, 0.75, 1.0].forEach(frac => {
+      const y = PAD_TOP + CHART_H - Math.round(frac * CHART_H);
+      gridLines += `<line x1="0" y1="${y}" x2="${totalW}" y2="${y}" stroke="${gridColor}" stroke-width="1"/>`;
+    });
+
+    for (let i = 0; i < numHours; i++) {
+      const hour = minHour + i;
+      const count = byHour[hour] || 0;
+      const barH = Math.max(1, Math.round(count / maxCount * CHART_H));
+      const x = i * (BAR_W + BAR_GAP);
+      const y = PAD_TOP + CHART_H - barH;
+
+      bars += `<rect x="${x}" y="${y}" width="${BAR_W}" height="${barH}" fill="${barColor}" rx="2" opacity="${count === 0 ? 0.08 : 0.85}"/>`;
+
+      // Label every 4 hours and the last hour
+      if (hour % 4 === 0 || i === numHours - 1) {
+        const lx = x + BAR_W / 2;
+        const label = String(hour).padStart(2, '0') + ':00';
+        labels += `<text x="${lx}" y="${PAD_TOP + CHART_H + 14}" font-size="8" fill="${labelColor}" text-anchor="middle" font-family="'Fira Code',monospace">${label}</text>`;
+      }
+
+      // Count label above tall bars
+      if (count > 0) {
+        const lx = x + BAR_W / 2;
+        labels += `<text x="${lx}" y="${y - 3}" font-size="7.5" fill="${labelColor}" text-anchor="middle" font-family="'Fira Code',monospace">${count}</text>`;
+      }
+    }
+
+    // Axis baseline
+    const baseline = `<line x1="0" y1="${PAD_TOP + CHART_H}" x2="${totalW}" y2="${PAD_TOP + CHART_H}" stroke="${gridColor}" stroke-width="1.5"/>`;
+
+    el.innerHTML = `<svg viewBox="0 0 ${totalW} ${svgH}" width="${Math.max(totalW, 480)}" height="${svgH}" style="min-width:${Math.max(totalW, 480)}px">
+      ${gridLines}${baseline}${bars}${labels}
+    </svg>`;
+  }
+
+  document.querySelectorAll('.freq-plot').forEach(drawPlot);
+})();
+</script>
+{% endblock %}

--- a/crates/server/templates/partials/frequency_content.html
+++ b/crates/server/templates/partials/frequency_content.html
@@ -24,12 +24,13 @@
   <div class="schedule-grid">
     {% for (i, row) in rows.iter().enumerate() %}
     <div class="card schedule-card">
-      <div class="schedule-card__header">
+      <a href="/schedule/{{ row.feed_id }}/{{ row.route_id }}" class="schedule-card__header" style="display:flex;text-decoration:none;color:inherit;">
         <div>
           <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
           <div class="schedule-card__name">{{ row.long_name }}</div>
         </div>
-      </div>
+        <span style="margin-left:auto;font-size:0.72rem;color:var(--link-blue);white-space:nowrap;align-self:center;">Details →</span>
+      </a>
       <div class="schedule-card__days">
         {% if row.weekday_headway_mins.is_some() %}
         <div class="day-col">


### PR DESCRIPTION
- New `route_hourly_frequency` query groups trips by hour and day type
  (weekday/saturday/sunday) using the same service classification logic
  as the headway query
- `RouteHourlyFrequency` / `HourBin` structs carry the data through to
  the template as JSON; `weekday_json()`, `saturday_json()`,
  `sunday_json()` serialize for the chart renderer
- `schedule_detail` handler at `/schedule/:feed_id/:route_id` returns
  a full-page Askama template; 404 when the route is not found
- `schedule_detail.html` template renders one SVG bar chart per
  available day type via vanilla JS reading CSS variables (dark-mode
  aware, no external chart library)
- Summary cards on `/schedule` now link to the detail page

https://claude.ai/code/session_019i9GRH7c9UXjMsEzv7ZQrJ