### PR TITLE
feat: schedule grouping accordion with span-based day-type buckets

### DIFF
--- a/.sqlx/query-0f2704e243a3b04c22197d375162f54908d322b96231488502b34bc0b63e9283.json
+++ b/.sqlx/query-0f2704e243a3b04c22197d375162f54908d322b96231488502b34bc0b63e9283.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO regions (id, name, timezone)\n         VALUES (1, $1, $2)\n         ON CONFLICT (id) DO UPDATE SET name = $1, timezone = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0f2704e243a3b04c22197d375162f54908d322b96231488502b34bc0b63e9283"
+}

--- a/.sqlx/query-155f7c76dce7f8b3063de26a09596105198f48a222603b04f30e17bcc11769e6.json
+++ b/.sqlx/query-155f7c76dce7f8b3063de26a09596105198f48a222603b04f30e17bcc11769e6.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO network_feeds (network_id, feed_id) VALUES (1, $1)\n             ON CONFLICT (network_id, feed_id) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "155f7c76dce7f8b3063de26a09596105198f48a222603b04f30e17bcc11769e6"
+}

--- a/.sqlx/query-771b00e6adf26fce67983fa5750aa88a4677c948ef058ea9bda81acbbe4e2767.json
+++ b/.sqlx/query-771b00e6adf26fce67983fa5750aa88a4677c948ef058ea9bda81acbbe4e2767.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(MAX(id), 0) FROM feeds",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "coalesce",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "771b00e6adf26fce67983fa5750aa88a4677c948ef058ea9bda81acbbe4e2767"
+}

--- a/.sqlx/query-aa0c3e65f57e0a354a84f26cb8905dc68213dd5fc076b3eb23d24640b2085887.json
+++ b/.sqlx/query-aa0c3e65f57e0a354a84f26cb8905dc68213dd5fc076b3eb23d24640b2085887.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM feeds WHERE transitland_onestop_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "aa0c3e65f57e0a354a84f26cb8905dc68213dd5fc076b3eb23d24640b2085887"
+}

--- a/.sqlx/query-aa663ae3dca26088d8482508024782a556dcc495c375dd91be7c395b06eff99b.json
+++ b/.sqlx/query-aa663ae3dca26088d8482508024782a556dcc495c375dd91be7c395b06eff99b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO networks (id, region_id, name)\n         VALUES (1, 1, $1)\n         ON CONFLICT (id) DO UPDATE SET name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aa663ae3dca26088d8482508024782a556dcc495c375dd91be7c395b06eff99b"
+}

--- a/.sqlx/query-bca76b5171623d4e59a9c77cb9d96f56a655b69b09c2bef4f5cafdf4ecc76aa5.json
+++ b/.sqlx/query-bca76b5171623d4e59a9c77cb9d96f56a655b69b09c2bef4f5cafdf4ecc76aa5.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, gtfs_static_url,\n                  gtfs_rt_vehicle_positions_url, gtfs_rt_trip_updates_url,\n                  transitland_onestop_id, gtfs_api_key, timezone\n           FROM feeds",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "gtfs_static_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "gtfs_rt_vehicle_positions_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "gtfs_rt_trip_updates_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "transitland_onestop_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "gtfs_api_key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "timezone",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "bca76b5171623d4e59a9c77cb9d96f56a655b69b09c2bef4f5cafdf4ecc76aa5"
+}

--- a/.sqlx/query-d0d98938f10cf6ce56e378c3a6678557551cb7bad7a2c9b919215aa7c3cbd0b8.json
+++ b/.sqlx/query-d0d98938f10cf6ce56e378c3a6678557551cb7bad7a2c9b919215aa7c3cbd0b8.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT f.id,\n                  STRING_AGG(a.name, ' / ' ORDER BY a.name) AS \"display_name!\"\n           FROM feeds f\n           JOIN feed_agency_ids fai ON fai.feed_id = f.id\n           JOIN agencies a ON a.onestop_id = fai.onestop_id\n           GROUP BY f.id\n           ORDER BY 2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "d0d98938f10cf6ce56e378c3a6678557551cb7bad7a2c9b919215aa7c3cbd0b8"
+}

--- a/.sqlx/query-e16c5ce0618219f8a64732e5a723bfceb54a92579646e29c4da036d928ab4714.json
+++ b/.sqlx/query-e16c5ce0618219f8a64732e5a723bfceb54a92579646e29c4da036d928ab4714.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO feeds (id, name, gtfs_static_url,\n                                gtfs_rt_vehicle_positions_url, gtfs_rt_trip_updates_url,\n                                transitland_onestop_id, timezone)\n             VALUES ($1, $2, $3, $4, $5, $6, $7)\n             ON CONFLICT (transitland_onestop_id) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e16c5ce0618219f8a64732e5a723bfceb54a92579646e29c4da036d928ab4714"
+}

--- a/config.toml
+++ b/config.toml
@@ -4,5 +4,5 @@ bind_address = "0.0.0.0:3000"
 on_time_early_threshold_secs = -60
 on_time_late_threshold_secs = 300
 retention_days = 30
-# transitland_api_key_env = "TRANSITLAND_API_KEY"
+transitland_api_key_env = "TRANSITLAND_API_KEY"
 worker_health_bind_address = "0.0.0.0:9090"

--- a/crates/core/src/db/feeds.rs
+++ b/crates/core/src/db/feeds.rs
@@ -24,6 +24,24 @@ pub async fn load_feeds(pool: &PgPool) -> Result<Vec<DbFeed>> {
     .await?)
 }
 
+pub async fn load_feed_options(pool: &PgPool) -> Result<Vec<(String, String)>> {
+    let rows = sqlx::query!(
+        r#"SELECT f.id,
+                  STRING_AGG(a.name, ' / ' ORDER BY a.name) AS "display_name!"
+           FROM feeds f
+           JOIN feed_agency_ids fai ON fai.feed_id = f.id
+           JOIN agencies a ON a.onestop_id = fai.onestop_id
+           GROUP BY f.id
+           ORDER BY 2"#
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.id.to_string(), r.display_name))
+        .collect())
+}
+
 pub async fn store_discovered_feeds(
     pool: &PgPool,
     city: &str,

--- a/crates/core/src/on_time_performance/on_time.rs
+++ b/crates/core/src/on_time_performance/on_time.rs
@@ -183,7 +183,15 @@ pub async fn compute_route_daily(
         .fetch_one(&db.pool)
         .await?;
 
-        let (trips_run, on_time_stops, total_stops, skipped_stops, avg_delay, max_delay, trips_total) = row;
+        let (
+            trips_run,
+            on_time_stops,
+            total_stops,
+            skipped_stops,
+            avg_delay,
+            max_delay,
+            trips_total,
+        ) = row;
 
         sqlx::query(
             "INSERT INTO route_daily_stats

--- a/crates/core/src/on_time_performance/route_summary.rs
+++ b/crates/core/src/on_time_performance/route_summary.rs
@@ -243,7 +243,15 @@ mod tests {
 
         // Insert two feeds
         sqlx::query(
-            "INSERT INTO feeds (id, onestop_id, name) VALUES (1, 'f-stm', 'STM'), (2, 'f-rtl', 'RTL')",
+            "INSERT INTO feeds (id, gtfs_static_url, name) VALUES (1, 'http://stm', 'STM'), (2, 'http://rtl', 'RTL')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        // Insert agencies required by routes FK
+        sqlx::query(
+            "INSERT INTO agencies (onestop_id, name) VALUES ('stm', 'STM'), ('rtl', 'RTL')",
         )
         .execute(&db.pool)
         .await

--- a/crates/core/src/on_time_performance/trend.rs
+++ b/crates/core/src/on_time_performance/trend.rs
@@ -149,7 +149,13 @@ mod tests {
         let db = td.db;
 
         // Insert required feed row
-        sqlx::query("INSERT INTO feeds (id, onestop_id, name) VALUES (1, 'f-test', 'Test')")
+        sqlx::query(
+            "INSERT INTO feeds (id, gtfs_static_url, name) VALUES (1, 'http://test', 'Test')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('test', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
@@ -186,7 +192,13 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO feeds (id, onestop_id, name) VALUES (1, 'f-test', 'Test')")
+        sqlx::query(
+            "INSERT INTO feeds (id, gtfs_static_url, name) VALUES (1, 'http://test', 'Test')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('test', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -1075,6 +1075,47 @@ mod tests {
     }
 
     #[test]
+    fn group_by_span_night_threshold_is_exactly_midnight() {
+        // 24*3600 = midnight: Night
+        let mut row = make_row(Some(30.0), None, None);
+        row.weekday_service_start_secs = Some(24 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups[0].title, "Night");
+
+        // 24*3600 - 1 = one second before midnight: not Night
+        let mut row2 = make_row(Some(30.0), None, None);
+        row2.weekday_service_start_secs = Some(24 * 3600 - 1);
+        let groups2 = group_by_span(vec![row2]);
+        assert_ne!(groups2[0].title, "Night");
+    }
+
+    #[test]
+    fn group_by_span_night_routes_sorted_by_headway_asc() {
+        let mut slow = make_row(Some(60.0), None, None);
+        slow.weekday_service_start_secs = Some(25 * 3600);
+        slow.route_id = RouteId::from("r-slow");
+
+        let mut fast = make_row(Some(15.0), None, None);
+        fast.weekday_service_start_secs = Some(25 * 3600);
+        fast.route_id = RouteId::from("r-fast");
+
+        let groups = group_by_span(vec![slow, fast]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Night");
+        assert_eq!(groups[0].rows[0].route_id, RouteId::from("r-fast"));
+        assert_eq!(groups[0].rows[1].route_id, RouteId::from("r-slow"));
+    }
+
+    #[test]
+    fn group_by_span_sunday_only_night_route_goes_to_night() {
+        let mut row = make_row(None, None, Some(30.0));
+        row.sunday_service_start_secs = Some(25 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Night");
+    }
+
+    #[test]
     fn group_by_span_night_appears_after_rush_hours_in_output() {
         // Every Day route
         let every_day = make_row(Some(10.0), Some(15.0), None);

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -286,7 +286,7 @@ fn classify(row: &RouteHeadwayRow) -> &'static str {
         .weekday_service_start_secs
         .or(row.saturday_service_start_secs)
         .or(row.sunday_service_start_secs);
-    if primary_start.map_or(false, |s| s >= 24 * 3600) {
+    if primary_start.is_some_and(|s| s >= 24 * 3600) {
         return "Night";
     }
 

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -123,7 +123,10 @@ ORDER BY day_type, hour";
     let mut sunday_bins = Vec::new();
 
     for row in rows {
-        let bin = HourBin { hour: row.hour, trip_count: row.trip_count };
+        let bin = HourBin {
+            hour: row.hour,
+            trip_count: row.trip_count,
+        };
         match row.day_type.as_deref() {
             Some("weekday") => weekday_bins.push(bin),
             Some("saturday") => saturday_bins.push(bin),
@@ -510,6 +513,11 @@ mod tests {
             .execute(&db.pool)
             .await
             .unwrap();
+        // Insert agency (required by FK constraint on routes.agency_id)
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('stm', 'STM')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
         // Insert route
         sqlx::query(
             "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-stm-R1', 'stm', '1', 'Route 1', 3)",
@@ -760,6 +768,11 @@ mod tests {
         .execute(&db.pool)
         .await
         .unwrap();
+        // Insert agency (required by FK constraint on routes.agency_id)
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('agency', 'Test Agency') ON CONFLICT DO NOTHING")
+            .execute(&db.pool)
+            .await
+            .unwrap();
         sqlx::query(&format!(
             "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('{route_id}', 'agency', '{short_name}', '{long_name}', 3)"
         ))
@@ -774,7 +787,14 @@ mod tests {
         .unwrap();
     }
 
-    async fn insert_service(db: &crate::db::Database, feed_id: i64, service_id: &str, weekday: bool, saturday: bool, sunday: bool) {
+    async fn insert_service(
+        db: &crate::db::Database,
+        feed_id: i64,
+        service_id: &str,
+        weekday: bool,
+        saturday: bool,
+        sunday: bool,
+    ) {
         sqlx::query(&format!(
             "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ({feed_id}, '{service_id}', {weekday}, {weekday}, {weekday}, {weekday}, {weekday}, {saturday}, {sunday})"
         ))
@@ -808,13 +828,10 @@ mod tests {
     #[tokio::test]
     async fn route_hourly_frequency_returns_none_for_unknown_route() {
         let td = test_utils::setup().await;
-        let result = route_hourly_frequency(
-            &td.db,
-            FeedId::from(1i64),
-            &RouteId::from("r-unknown"),
-        )
-        .await
-        .unwrap();
+        let result =
+            route_hourly_frequency(&td.db, FeedId::from(1i64), &RouteId::from("r-unknown"))
+                .await
+                .unwrap();
         assert!(result.is_none());
     }
 
@@ -885,7 +902,10 @@ mod tests {
         let freq = RouteHourlyFrequency {
             short_name: "1".to_string(),
             long_name: "Route 1".to_string(),
-            weekday_bins: vec![HourBin { hour: 8, trip_count: 3 }],
+            weekday_bins: vec![HourBin {
+                hour: 8,
+                trip_count: 3,
+            }],
             saturday_bins: vec![],
             sunday_bins: vec![],
         };

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -280,12 +280,13 @@ pub struct ScheduleGroup {
 
 /// Classify a single row into one of four display buckets.
 fn classify(row: &RouteHeadwayRow) -> &'static str {
-    // Night: primary service starts at or after 20:00 — checked first so it beats all other buckets.
+    // Night: primary service starts at or after midnight (GTFS past-midnight encoding: ≥ 24:00:00 = 86400s)
+    // — checked first so it beats all other buckets.
     let primary_start = row
         .weekday_service_start_secs
         .or(row.saturday_service_start_secs)
         .or(row.sunday_service_start_secs);
-    if primary_start.map_or(false, |s| s >= 20 * 3600) {
+    if primary_start.map_or(false, |s| s >= 24 * 3600) {
         return "Night";
     }
 
@@ -1029,7 +1030,7 @@ mod tests {
     #[test]
     fn group_by_span_weekday_night_route_goes_to_night() {
         let mut row = make_row(Some(30.0), None, None);
-        row.weekday_service_start_secs = Some(22 * 3600);
+        row.weekday_service_start_secs = Some(25 * 3600);
         let groups = group_by_span(vec![row]);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].title, "Night");
@@ -1038,7 +1039,7 @@ mod tests {
     #[test]
     fn group_by_span_weekend_night_route_goes_to_night() {
         let mut row = make_row(None, Some(30.0), None);
-        row.saturday_service_start_secs = Some(22 * 3600);
+        row.saturday_service_start_secs = Some(25 * 3600);
         let groups = group_by_span(vec![row]);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].title, "Night");
@@ -1048,7 +1049,7 @@ mod tests {
     fn group_by_span_every_day_night_route_goes_to_night() {
         // Would normally be "Every Day" (weekday + weekend) but night check beats it
         let mut row = make_row(Some(10.0), Some(15.0), None);
-        row.weekday_service_start_secs = Some(22 * 3600);
+        row.weekday_service_start_secs = Some(25 * 3600);
         let groups = group_by_span(vec![row]);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].title, "Night");
@@ -1064,6 +1065,16 @@ mod tests {
     }
 
     #[test]
+    fn group_by_span_route_starting_at_22_is_not_night() {
+        // 22:00 = 79200s < 86400s — must NOT go to Night
+        let mut row = make_row(Some(10.0), None, None);
+        row.weekday_service_start_secs = Some(22 * 3600); // 79200 < 86400
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_ne!(groups[0].title, "Night");
+    }
+
+    #[test]
     fn group_by_span_night_appears_after_rush_hours_in_output() {
         // Every Day route
         let every_day = make_row(Some(10.0), Some(15.0), None);
@@ -1072,7 +1083,7 @@ mod tests {
         rush.weekday_service_end_secs = Some(9 * 3600);
         // Night route
         let mut night = make_row(Some(30.0), None, None);
-        night.weekday_service_start_secs = Some(22 * 3600);
+        night.weekday_service_start_secs = Some(25 * 3600);
 
         let groups = group_by_span(vec![every_day, rush, night]);
         assert_eq!(groups[0].title, "Every Day");

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -278,8 +278,17 @@ pub struct ScheduleGroup {
     pub rows: Vec<RouteHeadwayRow>,
 }
 
-/// Classify a single row into one of three display buckets.
+/// Classify a single row into one of four display buckets.
 fn classify(row: &RouteHeadwayRow) -> &'static str {
+    // Night: primary service starts at or after 20:00 — checked first so it beats all other buckets.
+    let primary_start = row
+        .weekday_service_start_secs
+        .or(row.saturday_service_start_secs)
+        .or(row.sunday_service_start_secs);
+    if primary_start.map_or(false, |s| s >= 20 * 3600) {
+        return "Night";
+    }
+
     let has_weekday = row.weekday_headway_mins.is_some();
     let has_weekend = row.saturday_headway_mins.is_some() || row.sunday_headway_mins.is_some();
 
@@ -305,13 +314,18 @@ fn classify(row: &RouteHeadwayRow) -> &'static str {
 
 /// Group `RouteHeadwayRow` records into display buckets for the UI accordion.
 ///
-/// Groups are ordered: Every Day → Weekday — All Day → Weekday — Rush Hours.
+/// Groups are ordered: Every Day → Weekday — All Day → Weekday — Rush Hours → Night.
 /// Within each group rows are sorted by `primary_headway_min()` ascending.
 /// Empty groups are omitted from the output.
 pub fn group_by_span(rows: Vec<RouteHeadwayRow>) -> Vec<ScheduleGroup> {
-    const TITLES: [&str; 3] = ["Every Day", "Weekday — All Day", "Weekday — Rush Hours"];
+    const TITLES: [&str; 4] = [
+        "Every Day",
+        "Weekday — All Day",
+        "Weekday — Rush Hours",
+        "Night",
+    ];
 
-    let mut buckets: [Vec<RouteHeadwayRow>; 3] = [vec![], vec![], vec![]];
+    let mut buckets: [Vec<RouteHeadwayRow>; 4] = [vec![], vec![], vec![], vec![]];
 
     for row in rows {
         let title = classify(&row);
@@ -1008,6 +1022,61 @@ mod tests {
     fn sunday_badge_variant_delegates_to_headway() {
         let row = make_row(None, None, Some(25.0));
         assert_eq!(row.sunday_badge_variant(), "bad");
+    }
+
+    // --- Night bucket tests ---
+
+    #[test]
+    fn group_by_span_weekday_night_route_goes_to_night() {
+        let mut row = make_row(Some(30.0), None, None);
+        row.weekday_service_start_secs = Some(22 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Night");
+    }
+
+    #[test]
+    fn group_by_span_weekend_night_route_goes_to_night() {
+        let mut row = make_row(None, Some(30.0), None);
+        row.saturday_service_start_secs = Some(22 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Night");
+    }
+
+    #[test]
+    fn group_by_span_every_day_night_route_goes_to_night() {
+        // Would normally be "Every Day" (weekday + weekend) but night check beats it
+        let mut row = make_row(Some(10.0), Some(15.0), None);
+        row.weekday_service_start_secs = Some(22 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Night");
+    }
+
+    #[test]
+    fn group_by_span_daytime_route_is_not_night() {
+        // make_row sets weekday start at 6am — should be "Weekday — All Day", not "Night"
+        let row = make_row(Some(10.0), None, None);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_ne!(groups[0].title, "Night");
+    }
+
+    #[test]
+    fn group_by_span_night_appears_after_rush_hours_in_output() {
+        // Every Day route
+        let every_day = make_row(Some(10.0), Some(15.0), None);
+        // Rush Hours route: weekday-only, 3h span (start 06:00, end 09:00)
+        let mut rush = make_row(Some(10.0), None, None);
+        rush.weekday_service_end_secs = Some(9 * 3600);
+        // Night route
+        let mut night = make_row(Some(30.0), None, None);
+        night.weekday_service_start_secs = Some(22 * 3600);
+
+        let groups = group_by_span(vec![every_day, rush, night]);
+        assert_eq!(groups[0].title, "Every Day");
+        assert_eq!(groups[groups.len() - 1].title, "Night");
     }
 
     async fn setup_route(

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -284,7 +284,7 @@ fn classify(row: &RouteHeadwayRow) -> &'static str {
     let has_weekend = row.saturday_headway_mins.is_some() || row.sunday_headway_mins.is_some();
 
     // "Every Day": has weekday AND weekend, or no weekday data at all.
-    if !has_weekday || (has_weekday && has_weekend) {
+    if !has_weekday || has_weekend {
         return "Every Day";
     }
 
@@ -294,7 +294,7 @@ fn classify(row: &RouteHeadwayRow) -> &'static str {
         _ => 0,
     };
     let span_hours = span_secs as f64 / 3600.0;
-    let max_gap = row.weekday_max_headway_mins.unwrap_or(0.0);
+    let max_gap = row.weekday_max_headway_mins.unwrap_or(f64::INFINITY);
 
     if span_hours >= 8.0 && max_gap < 180.0 {
         "Weekday — All Day"
@@ -969,11 +969,27 @@ mod tests {
     }
 
     #[test]
-    fn group_by_span_omits_empty_groups() {
-        let row = make_row(Some(10.0), Some(20.0), None);
+    fn group_by_span_weekend_only_route_goes_to_every_day() {
+        let row = make_row(None, Some(20.0), None); // saturday-only, no weekday
         let groups = group_by_span(vec![row]);
-        // Only "Every Day" should be present; the other two groups are absent
         assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Every Day");
+    }
+
+    #[test]
+    fn group_by_span_omits_empty_groups() {
+        // Only every-day and all-day routes — rush-hours bucket should be absent
+        let every_day_row = make_row(Some(10.0), Some(15.0), None);
+        let all_day_row = make_row(Some(8.0), None, None); // weekday-only, wide span, small gap
+        let groups = group_by_span(vec![every_day_row, all_day_row]);
+        assert_eq!(
+            groups.len(),
+            2,
+            "rush-hours group should be omitted when empty"
+        );
+        assert_eq!(groups[0].title, "Every Day");
+        assert_eq!(groups[1].title, "Weekday — All Day");
+        assert!(!groups.iter().any(|g| g.title == "Weekday — Rush Hours"));
     }
 
     #[test]

--- a/crates/core/src/service_frequency/mod.rs
+++ b/crates/core/src/service_frequency/mod.rs
@@ -272,6 +272,75 @@ impl RouteHeadwayRow {
     }
 }
 
+#[derive(Debug)]
+pub struct ScheduleGroup {
+    pub title: &'static str,
+    pub rows: Vec<RouteHeadwayRow>,
+}
+
+/// Classify a single row into one of three display buckets.
+fn classify(row: &RouteHeadwayRow) -> &'static str {
+    let has_weekday = row.weekday_headway_mins.is_some();
+    let has_weekend = row.saturday_headway_mins.is_some() || row.sunday_headway_mins.is_some();
+
+    // "Every Day": has weekday AND weekend, or no weekday data at all.
+    if !has_weekday || (has_weekday && has_weekend) {
+        return "Every Day";
+    }
+
+    // Weekday-only: decide All Day vs Rush Hours.
+    let span_secs = match (row.weekday_service_start_secs, row.weekday_service_end_secs) {
+        (Some(s), Some(e)) => e - s,
+        _ => 0,
+    };
+    let span_hours = span_secs as f64 / 3600.0;
+    let max_gap = row.weekday_max_headway_mins.unwrap_or(0.0);
+
+    if span_hours >= 8.0 && max_gap < 180.0 {
+        "Weekday — All Day"
+    } else {
+        "Weekday — Rush Hours"
+    }
+}
+
+/// Group `RouteHeadwayRow` records into display buckets for the UI accordion.
+///
+/// Groups are ordered: Every Day → Weekday — All Day → Weekday — Rush Hours.
+/// Within each group rows are sorted by `primary_headway_min()` ascending.
+/// Empty groups are omitted from the output.
+pub fn group_by_span(rows: Vec<RouteHeadwayRow>) -> Vec<ScheduleGroup> {
+    const TITLES: [&str; 3] = ["Every Day", "Weekday — All Day", "Weekday — Rush Hours"];
+
+    let mut buckets: [Vec<RouteHeadwayRow>; 3] = [vec![], vec![], vec![]];
+
+    for row in rows {
+        let title = classify(&row);
+        let idx = TITLES.iter().position(|&t| t == title).unwrap();
+        buckets[idx].push(row);
+    }
+
+    let cmp = |a: &RouteHeadwayRow, b: &RouteHeadwayRow| {
+        a.primary_headway_min()
+            .partial_cmp(&b.primary_headway_min())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    };
+
+    TITLES
+        .iter()
+        .zip(buckets)
+        .filter_map(|(&title, mut bucket_rows)| {
+            if bucket_rows.is_empty() {
+                return None;
+            }
+            bucket_rows.sort_by(cmp);
+            Some(ScheduleGroup {
+                title,
+                rows: bucket_rows,
+            })
+        })
+        .collect()
+}
+
 pub async fn route_headways(
     db: &Database,
     feed_filter: Option<FeedId>,
@@ -482,6 +551,11 @@ WHERE ($1::BIGINT IS NULL OR rd.feed_id = $1)
 ORDER BY
     rd.feed_id,
     COALESCE(
+        ws.weekday_service_end_secs  - ws.weekday_service_start_secs,
+        ss_sat.saturday_service_end_secs - ss_sat.saturday_service_start_secs,
+        ss_sun.sunday_service_end_secs   - ss_sun.sunday_service_start_secs
+    ) DESC NULLS LAST,
+    COALESCE(
         wd.weekday_headway_mins,
         sat.saturday_headway_mins,
         sun.sunday_headway_mins
@@ -679,6 +753,106 @@ mod tests {
         assert_eq!(row.weekday_service_span_display(), "06:00-23:30");
     }
 
+    #[tokio::test]
+    async fn routes_sorted_by_span_desc_as_primary_key() {
+        let td = test_utils::setup().await;
+        let db = &td.db;
+
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (1, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('agency', 'Test Agency')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.5, -73.5)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        // Wide-span route: trips at hours 6 and 22 → span=16h, headway=960min
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-wide', 'agency', 'W', 'Wide', 3)")
+            .execute(&db.pool).await.unwrap();
+        sqlx::query("INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'VA', 'r-wide', 0, 1, 2, true)")
+            .execute(&db.pool).await.unwrap();
+
+        // Narrow-span route: trips at hours 9 and 17 → span=8h, headway=480min (better headway)
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-narrow', 'agency', 'N', 'Narrow', 3)")
+            .execute(&db.pool).await.unwrap();
+        sqlx::query("INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'VB', 'r-narrow', 0, 1, 2, true)")
+            .execute(&db.pool).await.unwrap();
+
+        sqlx::query("INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (1, 'WD', true, true, true, true, true, false, false)")
+            .execute(&db.pool).await.unwrap();
+
+        insert_trip_at_hour(db, 1, "W1", "WD", "VA", 6).await;
+        insert_trip_at_hour(db, 1, "W2", "WD", "VA", 22).await;
+        insert_trip_at_hour(db, 1, "N1", "WD", "VB", 9).await;
+        insert_trip_at_hour(db, 1, "N2", "WD", "VB", 17).await;
+
+        let rows = route_headways(db, None).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        // Wide-span route comes first even though narrow has better headway
+        assert_eq!(rows[0].route_id, RouteId::from("r-wide"));
+        assert_eq!(rows[1].route_id, RouteId::from("r-narrow"));
+    }
+
+    #[tokio::test]
+    async fn routes_with_same_span_sorted_by_headway_asc() {
+        let td = test_utils::setup().await;
+        let db = &td.db;
+
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (1, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('agency', 'Test Agency')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.5, -73.5)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        // Both routes: span 06:00–22:00 (16h)
+        // Slow route: 3 trips at hours 6, 14, 22 → headway=480min
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-slow', 'agency', 'S', 'Slow', 3)")
+            .execute(&db.pool).await.unwrap();
+        sqlx::query("INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'VS', 'r-slow', 0, 1, 3, true)")
+            .execute(&db.pool).await.unwrap();
+
+        // Fast route: 5 trips at hours 6, 10, 14, 18, 22 → headway=240min
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-fast', 'agency', 'F', 'Fast', 3)")
+            .execute(&db.pool).await.unwrap();
+        sqlx::query("INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (1, 'VF', 'r-fast', 0, 1, 5, true)")
+            .execute(&db.pool).await.unwrap();
+
+        sqlx::query("INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (1, 'WD', true, true, true, true, true, false, false)")
+            .execute(&db.pool).await.unwrap();
+
+        insert_trip_at_hour(db, 1, "S1", "WD", "VS", 6).await;
+        insert_trip_at_hour(db, 1, "S2", "WD", "VS", 14).await;
+        insert_trip_at_hour(db, 1, "S3", "WD", "VS", 22).await;
+
+        insert_trip_at_hour(db, 1, "F1", "WD", "VF", 6).await;
+        insert_trip_at_hour(db, 1, "F2", "WD", "VF", 10).await;
+        insert_trip_at_hour(db, 1, "F3", "WD", "VF", 14).await;
+        insert_trip_at_hour(db, 1, "F4", "WD", "VF", 18).await;
+        insert_trip_at_hour(db, 1, "F5", "WD", "VF", 22).await;
+
+        let rows = route_headways(db, None).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        // Same span (16h): fast route (240min) before slow route (480min)
+        assert_eq!(rows[0].route_id, RouteId::from("r-fast"));
+        assert_eq!(rows[1].route_id, RouteId::from("r-slow"));
+    }
+
     #[test]
     fn weekday_service_span_display_wraps_after_midnight() {
         let mut row = make_row(Some(8.0), None, None);
@@ -741,6 +915,71 @@ mod tests {
     fn weekday_badge_variant_delegates_to_headway() {
         let row = make_row(Some(8.0), None, None);
         assert_eq!(row.weekday_badge_variant(), "good");
+    }
+
+    // --- group_by_span tests ---
+
+    #[test]
+    fn group_by_span_weekend_route_goes_to_every_day() {
+        let row = make_row(Some(10.0), Some(20.0), None);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Every Day");
+    }
+
+    #[test]
+    fn group_by_span_wide_span_weekday_goes_to_all_day() {
+        // make_row sets span 06:00–23:30 (17.5h) and max_headway=30min → "Weekday — All Day"
+        let row = make_row(Some(10.0), None, None);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Weekday — All Day");
+    }
+
+    #[test]
+    fn group_by_span_short_span_goes_to_rush_hours() {
+        // 3h span → "Weekday — Rush Hours"
+        let mut row = make_row(Some(10.0), None, None);
+        row.weekday_service_end_secs = Some(9 * 3600);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Weekday — Rush Hours");
+    }
+
+    #[test]
+    fn group_by_span_large_gap_goes_to_rush_hours() {
+        // 5h max gap → "Weekday — Rush Hours"
+        let mut row = make_row(Some(10.0), None, None);
+        row.weekday_max_headway_mins = Some(300.0);
+        let groups = group_by_span(vec![row]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Weekday — Rush Hours");
+    }
+
+    #[test]
+    fn group_by_span_sorts_within_group_by_headway_asc() {
+        let slow = make_row(Some(30.0), Some(40.0), None);
+        let fast = make_row(Some(5.0), Some(10.0), None);
+        let groups = group_by_span(vec![slow, fast]);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].title, "Every Day");
+        // fast route (primary_headway=5.0) must come before slow (30.0)
+        assert_eq!(groups[0].rows[0].weekday_headway_mins, Some(5.0));
+        assert_eq!(groups[0].rows[1].weekday_headway_mins, Some(30.0));
+    }
+
+    #[test]
+    fn group_by_span_omits_empty_groups() {
+        let row = make_row(Some(10.0), Some(20.0), None);
+        let groups = group_by_span(vec![row]);
+        // Only "Every Day" should be present; the other two groups are absent
+        assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn group_by_span_empty_input_returns_empty() {
+        let groups = group_by_span(vec![]);
+        assert!(groups.is_empty());
     }
 
     #[test]

--- a/crates/core/src/speed_analysis/card.rs
+++ b/crates/core/src/speed_analysis/card.rs
@@ -321,10 +321,7 @@ mod tests {
 
     #[test]
     fn build_speed_cards_assigns_sequential_idx() {
-        let rows = vec![
-            make_row(1, "R1", 0, None),
-            make_row(1, "R2", 0, None),
-        ];
+        let rows = vec![make_row(1, "R1", 0, None), make_row(1, "R2", 0, None)];
         let names = HashMap::new();
         let cards = build_speed_cards(rows, &names);
         assert_eq!(cards[0].idx, 0);
@@ -356,7 +353,12 @@ mod tests {
         assert_eq!(cards.len(), 2);
     }
 
-    fn make_row_full(feed_id: i64, route_id: &str, variant_id: &str, weekday: Option<f64>) -> RouteSpeedDayType {
+    fn make_row_full(
+        feed_id: i64,
+        route_id: &str,
+        variant_id: &str,
+        weekday: Option<f64>,
+    ) -> RouteSpeedDayType {
         RouteSpeedDayType {
             feed_id: FeedId::from(feed_id),
             route_id: RouteId::from(route_id),
@@ -996,8 +998,14 @@ mod tests {
     #[test]
     fn filter_keeps_matching_class() {
         let cards = vec![
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
-            RouteSpeedCard { classification: Some(RouteClass::Rapid), ..make_card("R") },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Rapid),
+                ..make_card("R")
+            },
         ];
         let result = filter_speed_cards(cards, "rapid");
         assert_eq!(result.len(), 1);
@@ -1007,8 +1015,14 @@ mod tests {
     #[test]
     fn filter_empty_class_keeps_all() {
         let cards = vec![
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
-            RouteSpeedCard { classification: None, ..make_card("U") },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
+            RouteSpeedCard {
+                classification: None,
+                ..make_card("U")
+            },
         ];
         let result = filter_speed_cards(cards, "");
         assert_eq!(result.len(), 2);
@@ -1017,8 +1031,14 @@ mod tests {
     #[test]
     fn filter_hides_unclassified_when_class_given() {
         let cards = vec![
-            RouteSpeedCard { classification: None, ..make_card("U") },
-            RouteSpeedCard { classification: Some(RouteClass::Local), ..make_card("L") },
+            RouteSpeedCard {
+                classification: None,
+                ..make_card("U")
+            },
+            RouteSpeedCard {
+                classification: Some(RouteClass::Local),
+                ..make_card("L")
+            },
         ];
         let result = filter_speed_cards(cards, "local");
         assert_eq!(result.len(), 1);

--- a/crates/core/src/speed_analysis/mod.rs
+++ b/crates/core/src/speed_analysis/mod.rs
@@ -442,8 +442,8 @@ pub async fn route_stop_spacings(
                 av.direction_id,
                 av.is_primary,
                 av.trip_count,
-                s.stop_name,
-                s.stop_lat, s.stop_lon,
+                s.name AS stop_name,
+                s.lat AS stop_lat, s.lon AS stop_lon,
                 ROW_NUMBER() OVER (PARTITION BY av.variant_id ORDER BY rvs.stop_sequence) AS rn,
                 COUNT(*)    OVER (PARTITION BY av.variant_id)                              AS total_stops
             FROM all_variants av
@@ -568,7 +568,7 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
 
         for (trip_id,) in &trips {
             let stops: Vec<(f64, f64, String)> = sqlx::query_as(
-                "SELECT s.stop_lat, s.stop_lon, ss.arrival_time
+                "SELECT s.lat, s.lon, ss.arrival_time
                  FROM scheduled_stops ss
                  JOIN stops s ON s.onestop_id = ss.stop_id
                  WHERE ss.feed_id = $1 AND ss.trip_id = $2
@@ -607,7 +607,7 @@ pub async fn compute_route_speed(db: &Database, agency: &AgencyConfig) -> Result
 
         // Derive avg_stop_spacing_m from this variant's canonical stop list.
         let primary_stops: Vec<(f64, f64, String)> = sqlx::query_as(
-            "SELECT s.stop_lat, s.stop_lon, s.stop_name
+            "SELECT s.lat, s.lon, s.name
              FROM route_variant_stops rvs
              JOIN stops s ON s.onestop_id = rvs.stop_id
              WHERE rvs.feed_id = $1 AND rvs.variant_id = $2
@@ -725,17 +725,20 @@ pub async fn compute_route_speed_daily(
 
         for (trip_id,) in &trips {
             // Get the latest observed arrival_time per scheduled stop for this trip.
+            // Join on stop_id so each scheduled stop matches only its corresponding observed event.
             let stops: Vec<(f64, f64, chrono::DateTime<Utc>)> = sqlx::query_as(
-                "SELECT s.stop_lat, s.stop_lon,
+                "SELECT s.lat,
+                        s.lon,
                         MAX(ste.arrival_time) AS arrival_time
                  FROM stop_time_events ste
                  JOIN scheduled_stops ss
                    ON ss.feed_id = ste.feed_id AND ss.trip_id = ste.trip_id
+                  AND ss.stop_id = ste.stop_id
                  JOIN stops s ON s.onestop_id = ste.stop_id
                  WHERE ste.feed_id = $1 AND ste.trip_id = $2
                    AND ste.observed_at::DATE = $3::DATE
                    AND ste.arrival_time IS NOT NULL
-                 GROUP BY ss.stop_sequence, s.stop_lat, s.stop_lon
+                 GROUP BY ss.stop_sequence, s.lat, s.lon
                  ORDER BY ss.stop_sequence",
             )
             .bind(feed_id.as_i64())
@@ -905,16 +908,19 @@ pub async fn compute_route_speed_hourly(db: &Database, agency: &AgencyConfig) ->
 
         for (trip_id,) in &trips {
             // Get the latest observed arrival_time per scheduled stop for this trip.
+            // Join on stop_id so each scheduled stop matches only its corresponding observed event.
             let stops: Vec<(f64, f64, chrono::DateTime<Utc>)> = sqlx::query_as(
-                "SELECT s.stop_lat, s.stop_lon,
+                "SELECT s.lat,
+                        s.lon,
                         MAX(ste.arrival_time) AS arrival_time
                  FROM stop_time_events ste
                  JOIN scheduled_stops ss
                    ON ss.feed_id = ste.feed_id AND ss.trip_id = ste.trip_id
+                  AND ss.stop_id = ste.stop_id
                  JOIN stops s ON s.onestop_id = ste.stop_id
                  WHERE ste.feed_id = $1 AND ste.trip_id = $2
                    AND ste.arrival_time IS NOT NULL
-                 GROUP BY ss.stop_sequence, s.stop_lat, s.stop_lon
+                 GROUP BY ss.stop_sequence, s.lat, s.lon
                  ORDER BY ss.stop_sequence",
             )
             .bind(feed_id.as_i64())
@@ -1082,7 +1088,53 @@ mod tests {
     use super::*;
     use crate::config::AgencyConfig;
     use crate::db::test_utils;
-    use crate::ids::{AgencyId, FeedId};
+    use crate::ids::FeedId;
+
+    /// Insert the minimum static GTFS scaffolding required by speed-analysis tests:
+    /// feeds (id=0), agencies, routes, feed_route_ids — all keyed off feed_id = 0.
+    async fn seed_base(db: &Database) {
+        sqlx::query(
+            "INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test') \
+             ON CONFLICT DO NOTHING",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency') \
+             ON CONFLICT DO NOTHING",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '1', 'Route 1', 3) ON CONFLICT DO NOTHING",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO feed_route_ids (feed_id, gtfs_route_id, onestop_id) \
+             VALUES (0, 'R1', 'R1') ON CONFLICT DO NOTHING",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
+
+    /// Create a partition covering the years referenced by all speed-analysis tests
+    /// (the stop_time_events table is RANGE partitioned by observed_at and has no default).
+    async fn create_stop_time_events_partition(db: &Database) {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS stop_time_events_speed_test_part \
+             PARTITION OF stop_time_events \
+             FOR VALUES FROM ('2020-01-01') TO ('2030-01-01')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    }
 
     fn test_agency() -> AgencyConfig {
         AgencyConfig {
@@ -1131,30 +1183,52 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
         )
         .execute(&db.pool)
         .await
@@ -1163,7 +1237,7 @@ mod tests {
         compute_route_speed(&db, &test_agency()).await.unwrap();
 
         let row: (f64, i64) = sqlx::query_as(
-            "SELECT scheduled_speed_mps, trip_count FROM route_speed WHERE route_id = 'R1' AND direction_id = 0"
+            "SELECT scheduled_speed_mps, trip_count FROM route_speed WHERE feed_id = 0 AND route_id = 'R1'",
         )
         .fetch_one(&db.pool)
         .await
@@ -1182,46 +1256,68 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        seed_base(&db).await;
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 3, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        // Three trips: weekday, Saturday, Sunday — each on the same variant.
+        for (trip_id, svc) in [("T_WD", "WD"), ("T_SAT", "SAT"), ("T_SUN", "SUN")] {
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+                 VALUES (0, $1, 'VAR1', $2)",
+            )
+            .bind(trip_id)
+            .bind(svc)
             .execute(&db.pool)
             .await
             .unwrap();
-        // Three trips: weekday, Saturday, Sunday — each on the same stop pair.
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_WD', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_SAT', 'R1', 'SAT', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_SUN', 'R1', 'SUN', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        }
         // Weekday: 10 min → ~1.852 m/s
         for (trip_id, dep, arr) in [
             ("T_WD", "08:00:00", "08:10:00"),
             ("T_SAT", "08:00:00", "08:20:00"), // 20 min → ~0.926 m/s
             ("T_SUN", "08:00:00", "08:15:00"), // 15 min → ~1.235 m/s
         ] {
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0', '{trip_id}', 'S1', 1, '{dep}', '{dep}')"
-            ))
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+                 VALUES (0, $1, 'S1', 1, $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(dep)
             .execute(&db.pool)
             .await
             .unwrap();
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0', '{trip_id}', 'S2', 2, '{arr}', '{arr}')"
-            ))
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+                 VALUES (0, $1, 'S2', 2, $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(arr)
             .execute(&db.pool)
             .await
             .unwrap();
@@ -1230,7 +1326,7 @@ mod tests {
         compute_route_speed(&db, &test_agency()).await.unwrap();
 
         let row: (f64, i64) = sqlx::query_as(
-            "SELECT scheduled_speed_mps, trip_count FROM route_speed WHERE route_id = 'R1' AND direction_id = 0",
+            "SELECT scheduled_speed_mps, trip_count FROM route_speed WHERE feed_id = 0 AND route_id = 'R1'",
         )
         .fetch_one(&db.pool)
         .await
@@ -1250,50 +1346,59 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // Trip in direction 0 (outbound): S1 → S2
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Outbound')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // Trip in direction 1 (inbound): S2 → S1
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T2', 'R1', 'WD', 1, 'Inbound')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // Outbound: S1 at 08:00, S2 at 08:10
+        seed_base(&db).await;
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        // Two primary variants — one per direction.
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR_OUT', 'R1', 0, 2, 1, true), \
+                    (0, 'VAR_IN',  'R1', 1, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR_OUT', 'S1', 1), (0, 'VAR_OUT', 'S2', 2), \
+                    (0, 'VAR_IN',  'S2', 1), (0, 'VAR_IN',  'S1', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR_OUT', 'WD'), (0, 'T2', 'VAR_IN', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        // Outbound: S1 at 08:00, S2 at 08:10
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         // Inbound: S2 at 09:00, S1 at 09:10
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T2', 'S2', 1, '09:00:00', '09:00:00')",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T2', 'S1', 2, '09:10:00', '09:10:00')",
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T2', 'S2', 1, '09:00:00', '09:00:00'), \
+                    (0, 'T2', 'S1', 2, '09:10:00', '09:10:00')",
         )
         .execute(&db.pool)
         .await
@@ -1301,8 +1406,9 @@ mod tests {
 
         compute_route_speed(&db, &test_agency()).await.unwrap();
 
-        let rows: Vec<(i64, f64)> = sqlx::query_as(
-            "SELECT direction_id, scheduled_speed_mps FROM route_speed WHERE route_id = 'R1' ORDER BY direction_id",
+        let rows: Vec<(String, f64)> = sqlx::query_as(
+            "SELECT variant_id, scheduled_speed_mps FROM route_speed \
+             WHERE feed_id = 0 AND route_id = 'R1' ORDER BY variant_id",
         )
         .fetch_all(&db.pool)
         .await
@@ -1311,12 +1417,10 @@ mod tests {
         assert_eq!(
             rows.len(),
             2,
-            "expected one row per direction, got {}",
+            "expected one row per direction (variant), got {}",
             rows.len()
         );
-        assert_eq!(rows[0].0, 0, "first row should be direction 0");
-        assert_eq!(rows[1].0, 1, "second row should be direction 1");
-        // Both directions cover the same distance in the same time, so speeds should match.
+        // Both variants cover the same distance in the same time, so speeds should match.
         assert!(
             (rows[0].1 - rows[1].1).abs() < 0.01,
             "outbound and inbound speeds should be equal, got {} vs {}",
@@ -1330,12 +1434,24 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '42', 'The Answer', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0', 'R1', 0, 10.0, 5, '2026-01-01T00:00:00Z')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '42', 'The Answer', 3)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 10.0, 5, '2026-01-01T00:00:00Z')",
         )
         .execute(&db.pool)
         .await
@@ -1355,41 +1471,58 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
-        let t_s1: i64 = 1767225600;
-        let t_s2: i64 = t_s1 + 900;
+        let t_s1 = chrono::DateTime::from_timestamp(1_767_225_600, 0).unwrap();
+        let t_s2 = chrono::DateTime::from_timestamp(1_767_225_600 + 900, 0).unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', '2026-01-01T08:00:00Z', 'T1', 'S1', 1, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, '2026-01-01T08:00:00Z', 'T1', 'S1', 1, $1)",
         )
         .bind(t_s1)
         .execute(&db.pool)
@@ -1397,8 +1530,8 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', '2026-01-01T08:15:00Z', 'T1', 'S2', 2, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, '2026-01-01T08:15:00Z', 'T1', 'S2', 2, $1)",
         )
         .bind(t_s2)
         .execute(&db.pool)
@@ -1410,16 +1543,17 @@ mod tests {
             .await
             .unwrap();
 
-        let row: (f64, i64) = sqlx::query_as(
-            "SELECT actual_speed_mps, trip_count
-             FROM route_speed_daily
-             WHERE route_id = 'R1' AND service_date = '2026-01-01' AND direction_id = 0",
+        let row: (Option<f64>, i64) = sqlx::query_as(
+            "SELECT actual_speed_mps, trips_run
+             FROM route_daily_stats
+             WHERE feed_id = 0 AND route_id = 'R1' AND service_date = '2026-01-01'",
         )
         .fetch_one(&db.pool)
         .await
         .unwrap();
 
         let (speed, count) = row;
+        let speed = speed.expect("expected actual_speed_mps to be Some");
         assert!(
             (speed - 1.235).abs() < 0.05,
             "expected ~1.235 m/s, got {speed}"
@@ -1432,45 +1566,51 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // Trip T1 with variant_id set
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
         sqlx::query(
-            "INSERT INTO trips (agency_id, trip_id, route_id, service_id, direction_id, variant_id)
-             VALUES ('0', 'T1', 'R1', 'WD', 0, 'VAR1')",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
-        let t_s1: i64 = 1767225600;
-        let t_s2: i64 = t_s1 + 900;
+        let t_s1 = chrono::DateTime::from_timestamp(1_767_225_600, 0).unwrap();
+        let t_s2 = chrono::DateTime::from_timestamp(1_767_225_600 + 900, 0).unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', '2026-01-01T08:00:00Z', 'T1', 'S1', 1, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, '2026-01-01T08:00:00Z', 'T1', 'S1', 1, $1)",
         )
         .bind(t_s1)
         .execute(&db.pool)
@@ -1478,8 +1618,8 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', '2026-01-01T08:15:00Z', 'T1', 'S2', 2, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, '2026-01-01T08:15:00Z', 'T1', 'S2', 2, $1)",
         )
         .bind(t_s2)
         .execute(&db.pool)
@@ -1492,7 +1632,8 @@ mod tests {
             .unwrap();
 
         let variant_id: (String,) = sqlx::query_as(
-            "SELECT variant_id FROM route_speed_daily WHERE route_id = 'R1' AND service_date = '2026-01-01'",
+            "SELECT variant_id FROM route_daily_stats \
+             WHERE feed_id = 0 AND route_id = 'R1' AND service_date = '2026-01-01'",
         )
         .fetch_one(&db.pool)
         .await
@@ -1505,21 +1646,37 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '99', 'Route 99', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0', 'R1', 0, 8.0, 3, '2026-01-01T00:00:00Z')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '99', 'Route 99', 3)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', (CURRENT_DATE - 1)::TEXT, 0, 6.5, 10, '2026-01-01T00:00:00Z')"
-        ).execute(&db.pool).await.unwrap();
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 3, '2026-01-01T00:00:00Z')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, \
+              trips_run, trips_total, actual_speed_mps, computed_at)
+             VALUES (0, 'R1', CURRENT_DATE - 1, 'VAR1', 0, 0, 0, 10, 10, 6.5, '2026-01-01T00:00:00Z')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         let summary = route_speed_summary(&db, None).await.unwrap();
 
@@ -1536,12 +1693,24 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '99', 'Route 99', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0', 'R1', 0, 8.0, 3, '2026-01-01T00:00:00Z')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '99', 'Route 99', 3)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 3, '2026-01-01T00:00:00Z')",
         )
         .execute(&db.pool)
         .await
@@ -1568,13 +1737,21 @@ mod tests {
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-stm-R1', 'stm', '15', 'Papineau', 3)",
+            "INSERT INTO agencies (onestop_id, name) VALUES ('stm', 'STM'), ('rtl', 'RTL')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-rtl-R2', 'rtl', '10', 'Longueuil', 3)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('r-stm-R1', 'stm', '15', 'Papineau', 3)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('r-rtl-R2', 'rtl', '10', 'Longueuil', 3)",
         )
         .execute(&db.pool)
         .await
@@ -1615,43 +1792,54 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
         // Use timestamps within the last 4 hours so the hourly query picks them up.
-        let t_s1 = chrono::Utc::now().timestamp() - 1800; // 30 min ago
-        let t_s2 = t_s1 + 900; // 15 min later
+        let now = chrono::Utc::now();
+        let t_s1 = now - chrono::Duration::seconds(1800); // 30 min ago
+        let t_s2 = t_s1 + chrono::Duration::seconds(900); // 15 min later
 
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', NOW()::TEXT, 'T1', 'S1', 1, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, NOW(), 'T1', 'S1', 1, $1)",
         )
         .bind(t_s1)
         .execute(&db.pool)
@@ -1659,8 +1847,8 @@ mod tests {
         .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', NOW()::TEXT, 'T1', 'S2', 2, $1)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (0, NOW(), 'T1', 'S2', 2, $1)",
         )
         .bind(t_s2)
         .execute(&db.pool)
@@ -1674,7 +1862,7 @@ mod tests {
         let row: (f64, i64) = sqlx::query_as(
             "SELECT actual_speed_mps, trip_count
              FROM route_speed_hourly
-             WHERE agency_id = '0' AND route_id = 'R1' AND direction_id = 0",
+             WHERE feed_id = 0 AND route_id = 'R1' AND variant_id = 'VAR1'",
         )
         .fetch_one(&db.pool)
         .await
@@ -1867,286 +2055,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_route_speed_by_day_type_stores_speed_per_day_type() {
-        let td = test_utils::setup().await;
-        let db = td.db;
-
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_WD',  'R1', 'WD',  0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_SAT', 'R1', 'SAT', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T_SUN', 'R1', 'SUN', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-
-        // Calendar: WD = Mon-Fri, SAT = Saturday only, SUN = Sunday only.
-        sqlx::query("INSERT INTO calendar VALUES ('0','WD', true,true,true,true,true,false,false)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query(
-            "INSERT INTO calendar VALUES ('0','SAT',false,false,false,false,false,true,false)",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO calendar VALUES ('0','SUN',false,false,false,false,false,false,true)",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-
-        // Two stops ~1111 m apart.
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-
-        // WD: 10 min → ~1.852 m/s; SAT: 20 min → ~0.926 m/s; SUN: 15 min → ~1.235 m/s
-        for (trip_id, arr) in [
-            ("T_WD", "08:10:00"),
-            ("T_SAT", "08:20:00"),
-            ("T_SUN", "08:15:00"),
-        ] {
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0','{trip_id}','S1',1,'08:00:00','08:00:00')"
-            ))
-            .execute(&db.pool)
-            .await
-            .unwrap();
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0','{trip_id}','S2',2,'{arr}','{arr}')"
-            ))
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        }
-
-        compute_route_speed_by_day_type(&db, &test_agency())
-            .await
-            .unwrap();
-
-        let rows: Vec<(String, f64, i64)> = sqlx::query_as(
-            "SELECT day_type, scheduled_speed_mps, trip_count
-             FROM route_speed_day_type
-             WHERE agency_id = '0' AND route_id = 'R1' AND direction_id = 0
-             ORDER BY day_type",
-        )
-        .fetch_all(&db.pool)
-        .await
-        .unwrap();
-
-        assert_eq!(rows.len(), 3, "expected one row per day type");
-
-        let sat = rows.iter().find(|r| r.0 == "saturday").unwrap();
-        let sun = rows.iter().find(|r| r.0 == "sunday").unwrap();
-        let wd = rows.iter().find(|r| r.0 == "weekday").unwrap();
-
-        assert_eq!(wd.2, 1, "weekday trip_count");
-        assert_eq!(sat.2, 1, "saturday trip_count");
-        assert_eq!(sun.2, 1, "sunday trip_count");
-
-        assert!(
-            (wd.1 - 1.852).abs() < 0.05,
-            "weekday speed ~1.852 m/s, got {}",
-            wd.1
-        );
-        assert!(
-            (sat.1 - 0.926).abs() < 0.05,
-            "saturday speed ~0.926 m/s, got {}",
-            sat.1
-        );
-        assert!(
-            (sun.1 - 1.235).abs() < 0.05,
-            "sunday speed ~1.235 m/s, got {}",
-            sun.1
-        );
-    }
-
-    #[tokio::test]
     async fn route_speed_by_day_type_returns_scheduled_speeds_from_calendar() {
+        // route_speed_by_day_type returns the same scheduled speed for all three day types
+        // (weekday/saturday/sunday) — there's no longer a per-day-type scheduled breakdown.
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0','R1','1','Route 1',3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0','R1',0,10.0,5,'2026-01-01T00:00:00Z')")
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed_day_type
-             (agency_id,route_id,direction_id,day_type,scheduled_speed_mps,trip_count,computed_at)
-             VALUES ('0','R1',0,'weekday',8.0,10,'2026-01-01T00:00:00Z')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '1', 'Route 1', 3)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed_day_type
-             (agency_id,route_id,direction_id,day_type,scheduled_speed_mps,trip_count,computed_at)
-             VALUES ('0','R1',0,'saturday',6.0,5,'2026-01-01T00:00:00Z')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 10.0, 5, '2026-01-01T00:00:00Z')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
-        let rows = route_speed_by_day_type(&db, Some(FeedId::from(1i64)))
+        let rows = route_speed_by_day_type(&db, Some(FeedId::from(0i64)))
             .await
             .unwrap();
 
         assert_eq!(rows.len(), 1);
         let r = &rows[0];
+        // All three day-type scheduled speeds come from the single route_speed row,
+        // so they should all equal 10.0.
         assert!(
-            (r.weekday_speed_mps.unwrap() - 8.0).abs() < 0.01,
-            "weekday speed should be 8.0, got {:?}",
+            (r.weekday_speed_mps.unwrap() - 10.0).abs() < 0.01,
+            "weekday speed should equal scheduled (10.0), got {:?}",
             r.weekday_speed_mps
         );
         assert!(
-            (r.saturday_speed_mps.unwrap() - 6.0).abs() < 0.01,
-            "saturday speed should be 6.0, got {:?}",
+            (r.saturday_speed_mps.unwrap() - 10.0).abs() < 0.01,
+            "saturday speed should equal scheduled (10.0), got {:?}",
             r.saturday_speed_mps
         );
         assert!(
-            r.sunday_speed_mps.is_none(),
-            "sunday should be None when no row exists"
-        );
-    }
-
-    /// Integration test: calendar_dates.txt only (no calendar.txt) → speed by day type is computed.
-    /// This covers the STM case where the feed uses calendar_dates exclusively.
-    #[tokio::test]
-    async fn compute_route_speed_by_day_type_with_calendar_dates_only() {
-        let td = test_utils::setup().await;
-        let db = td.db;
-
-        // Seed routes, trips with service_ids that only appear in calendar_dates.
-        sqlx::query("INSERT INTO routes VALUES ('0','R1','1','Route 1',3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        for (trip_id, svc) in [
-            ("T_WD", "SVC_WD"),
-            ("T_SAT", "SVC_SAT"),
-            ("T_SUN", "SVC_SUN"),
-        ] {
-            sqlx::query(&format!(
-                "INSERT INTO trips VALUES ('0','{trip_id}','R1','{svc}',0,'Dest')"
-            ))
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        }
-        for (sid, lat) in [("S1", 45.50_f64), ("S2", 45.51_f64)] {
-            sqlx::query(&format!(
-                "INSERT INTO stops VALUES ('0','{sid}','Stop',$1,-73.50)"
-            ))
-            .bind(lat)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        }
-        // WD: 10 min → ~1.852 m/s  SAT: 20 min → ~0.926 m/s  SUN: 15 min → ~1.235 m/s
-        for (trip_id, arr) in [
-            ("T_WD", "08:10:00"),
-            ("T_SAT", "08:20:00"),
-            ("T_SUN", "08:15:00"),
-        ] {
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0','{trip_id}','S1',1,'08:00:00','08:00:00')"
-            ))
-            .execute(&db.pool)
-            .await
-            .unwrap();
-            sqlx::query(&format!(
-                "INSERT INTO scheduled_stops VALUES ('0','{trip_id}','S2',2,'{arr}','{arr}')"
-            ))
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        }
-
-        // Seed calendar rows directly, simulating what load_calendar_from_dates synthesizes
-        // from calendar_dates.txt (the STM case — no calendar.txt).
-        // 2026-01-05 = Monday → SVC_WD weekday; 2026-01-10 = Saturday; 2026-01-11 = Sunday
-        for (svc, mon, tue, wed, thu, fri, sat, sun) in [
-            ("SVC_WD", true, true, true, true, true, false, false),
-            ("SVC_SAT", false, false, false, false, false, true, false),
-            ("SVC_SUN", false, false, false, false, false, false, true),
-        ] {
-            sqlx::query(
-                "INSERT INTO calendar \
-                 (agency_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) \
-                 VALUES ('0', $1, $2, $3, $4, $5, $6, $7, $8)",
-            )
-            .bind(svc)
-            .bind(mon)
-            .bind(tue)
-            .bind(wed)
-            .bind(thu)
-            .bind(fri)
-            .bind(sat)
-            .bind(sun)
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        }
-
-        compute_route_speed_by_day_type(&db, &test_agency())
-            .await
-            .unwrap();
-
-        let rows: Vec<(String, f64)> = sqlx::query_as(
-            "SELECT day_type, scheduled_speed_mps
-             FROM route_speed_day_type
-             WHERE agency_id = '0' AND route_id = 'R1' AND direction_id = 0
-             ORDER BY day_type",
-        )
-        .fetch_all(&db.pool)
-        .await
-        .unwrap();
-
-        assert_eq!(
-            rows.len(),
-            3,
-            "expected one row per day type, got {}",
-            rows.len()
-        );
-
-        let wd = rows.iter().find(|r| r.0 == "weekday").unwrap();
-        let sat = rows.iter().find(|r| r.0 == "saturday").unwrap();
-        let sun = rows.iter().find(|r| r.0 == "sunday").unwrap();
-
-        assert!(
-            (wd.1 - 1.852).abs() < 0.05,
-            "weekday ~1.852 m/s, got {}",
-            wd.1
-        );
-        assert!(
-            (sat.1 - 0.926).abs() < 0.05,
-            "saturday ~0.926 m/s, got {}",
-            sat.1
-        );
-        assert!(
-            (sun.1 - 1.235).abs() < 0.05,
-            "sunday ~1.235 m/s, got {}",
-            sun.1
+            (r.sunday_speed_mps.unwrap() - 10.0).abs() < 0.01,
+            "sunday speed should equal scheduled (10.0), got {:?}",
+            r.sunday_speed_mps
         );
     }
 
@@ -2162,25 +2121,35 @@ mod tests {
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-a-R1', 'agency_a', '1', 'Route 1', 3)",
+            "INSERT INTO agencies (onestop_id, name) VALUES ('agency_a', 'A'), ('agency_b', 'B')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('r-b-R2', 'agency_b', '2', 'Route 2', 3)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('r-a-R1', 'agency_a', '1', 'Route 1', 3)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) VALUES (10, 'r-a-R1', 'VA', 10.0, 1, '2026-01-01')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('r-b-R2', 'agency_b', '2', 'Route 2', 3)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) VALUES (20, 'r-b-R2', 'VB', 12.0, 1, '2026-01-01')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (10, 'r-a-R1', 'VA', 10.0, 1, '2026-01-01')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (20, 'r-b-R2', 'VB', 12.0, 1, '2026-01-01')",
         )
         .execute(&db.pool)
         .await
@@ -2199,48 +2168,16 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        // Set up route, trip, stops
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
-        )
-        .execute(&db.pool)
-        .await
-        .unwrap();
-        compute_route_speed(&db, &test_agency()).await.unwrap();
-
-        // Seed route_speed_day_type for the scheduled side
-        sqlx::query(
-            "INSERT INTO route_speed_day_type
-             (agency_id, route_id, direction_id, day_type, scheduled_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 'weekday', 1.852, 1, '2026-01-01')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 1.852, 1, '2026-01-01T00:00:00Z')",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
-        // Seed route_speed_daily with a recent weekday row (within 28 days)
+        // Seed route_daily_stats with a recent weekday row (within 28 days)
         // and an old row that should be excluded (2 years ago)
         let recent_monday = {
             use chrono::{Datelike, Duration, Local};
@@ -2248,20 +2185,21 @@ mod tests {
             let days_from_monday = today.weekday().num_days_from_monday() as i64;
             today - Duration::days(days_from_monday + 7)
         };
-        let recent_monday_str = recent_monday.format("%Y-%m-%d").to_string();
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', $1, 0, 2.0, 1, $1)",
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, \
+              trips_run, trips_total, actual_speed_mps, computed_at)
+             VALUES (0, 'R1', $1, 'VAR1', 0, 0, 0, 1, 1, 2.0, NOW())",
         )
-        .bind(&recent_monday_str)
+        .bind(recent_monday)
         .execute(&db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', '2024-01-01', 0, 99.0, 1, '2024-01-01')",
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, \
+              trips_run, trips_total, actual_speed_mps, computed_at)
+             VALUES (0, 'R1', '2024-01-01', 'VAR1', 0, 0, 0, 1, 1, 99.0, '2024-01-01')",
         )
         .execute(&db.pool)
         .await
@@ -2290,13 +2228,24 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '99', 'Route 99', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency')")
             .execute(&db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at, last_stop_name)
-             VALUES ('0', 'R1', 0, 8.0, 3, '2026-01-01T00:00:00Z', 'Last Stop')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) \
+             VALUES ('R1', 'A1', '99', 'Route 99', 3)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at, last_stop_name) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 3, '2026-01-01T00:00:00Z', 'Last Stop')",
         )
         .execute(&db.pool)
         .await
@@ -2317,14 +2266,11 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at, last_stop_name)
-             VALUES ('0', 'R1', 0, 8.0, 1111.0, 1, '2026-01-01T00:00:00Z', 'Last Stop')",
+             (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at, last_stop_name) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 1111.0, 1, '2026-01-01T00:00:00Z', 'Last Stop')",
         )
         .execute(&db.pool)
         .await
@@ -2345,35 +2291,11 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // S1→S2: ~1111 m apart (0.01° latitude)
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 8.0, 1111.0, 1, '2026-01-01T00:00:00Z')",
+             (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 1111.0, 1, '2026-01-01T00:00:00Z')",
         )
         .execute(&db.pool)
         .await
@@ -2396,56 +2318,58 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 2, 1, true)",
-        ).execute(&db.pool).await.unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         compute_route_speed(&db, &test_agency()).await.unwrap();
 
-        let persisted: (Option<f64>,) =
-            sqlx::query_as("SELECT avg_stop_spacing_m FROM route_speed WHERE route_id = 'R1'")
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
+        let persisted: (Option<f64>,) = sqlx::query_as(
+            "SELECT avg_stop_spacing_m FROM route_speed WHERE feed_id = 0 AND route_id = 'R1'",
+        )
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
         assert!(
             persisted.0.is_some(),
             "compute_route_speed should persist avg_stop_spacing_m"
         );
 
-        sqlx::query("DELETE FROM scheduled_stops WHERE agency_id = '0'")
+        sqlx::query("DELETE FROM scheduled_stops WHERE feed_id = 0")
             .execute(&db.pool)
             .await
             .unwrap();
@@ -2461,29 +2385,27 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 8.0, 500.0, 1, '2026-01-01T00:00:00Z')",
+             (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 500.0, 1, '2026-01-01T00:00:00Z')",
         )
-        .execute(&db.pool).await.unwrap();
+        .execute(&db.pool)
+        .await
+        .unwrap();
         // Two weekday rows within the 28-day window with avg_dwell_secs
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, avg_dwell_secs, computed_at)
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, \
+              trips_run, trips_total, actual_speed_mps, avg_dwell_secs, computed_at)
              VALUES
-               ('0', 'R1', (CURRENT_DATE - INTERVAL '2 days')::TEXT, 0, 5.0, 10, 25.0, '2026-01-01T00:00:00Z'),
-               ('0', 'R1', (CURRENT_DATE - INTERVAL '3 days')::TEXT, 0, 5.0, 10, 35.0, '2026-01-01T00:00:00Z')",
+               (0, 'R1', CURRENT_DATE - INTERVAL '2 days', 'VAR1', 0, 0, 0, 10, 10, 5.0, 25.0, '2026-01-01T00:00:00Z'),
+               (0, 'R1', CURRENT_DATE - INTERVAL '3 days', 'VAR1', 0, 0, 0, 10, 10, 5.0, 35.0, '2026-01-01T00:00:00Z')",
         )
-        .execute(&db.pool).await.unwrap();
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         let rows = route_speed_by_day_type(&db, None).await.unwrap();
         assert_eq!(rows.len(), 1);
@@ -2501,26 +2423,24 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
             "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 8.0, 500.0, 1, '2026-01-01T00:00:00Z')",
+             (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) \
+             VALUES (0, 'R1', 'VAR1', 8.0, 500.0, 1, '2026-01-01T00:00:00Z')",
         )
-        .execute(&db.pool).await.unwrap();
+        .execute(&db.pool)
+        .await
+        .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, avg_dwell_secs, computed_at)
-             VALUES ('0', 'R1', (CURRENT_DATE - INTERVAL '1 day')::TEXT, 0, 5.0, 10, NULL, '2026-01-01T00:00:00Z')",
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, \
+              trips_run, trips_total, actual_speed_mps, avg_dwell_secs, computed_at)
+             VALUES (0, 'R1', CURRENT_DATE - INTERVAL '1 day', 'VAR1', 0, 0, 0, 10, 10, 5.0, NULL, '2026-01-01T00:00:00Z')",
         )
-        .execute(&db.pool).await.unwrap();
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         let rows = route_speed_by_day_type(&db, None).await.unwrap();
         assert_eq!(rows.len(), 1);
@@ -2533,45 +2453,71 @@ mod tests {
         let db = td.db;
         let agency = test_agency();
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        // S1: arrive 1000, depart 1030 → dwell_secs = 30
-        // S2: arrive 1700, depart 1720 → dwell_secs = 20
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        // S1: arrive @ +1000s, depart @ +1030s → dwell_secs = 30
+        // S2: arrive @ +1700s, depart @ +1720s → dwell_secs = 20
         // avg = 25.0
+        let s1_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 1_000, 0).unwrap();
+        let s1_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 1_030, 0).unwrap();
+        let s2_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 1_700, 0).unwrap();
+        let s2_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 1_720, 0).unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-             VALUES ('0','2026-04-01T08:00:00Z','T1','S1',1,1000,1030)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (0, '2026-04-01T08:00:00Z', 'T1', 'S1', 1, $1, $2)",
         )
-        .execute(&db.pool).await.unwrap();
+        .bind(s1_arr)
+        .bind(s1_dep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-             VALUES ('0','2026-04-01T08:10:00Z','T1','S2',2,1700,1720)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (0, '2026-04-01T08:10:00Z', 'T1', 'S2', 2, $1, $2)",
         )
-        .execute(&db.pool).await.unwrap();
+        .bind(s2_arr)
+        .bind(s2_dep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         let service_date = chrono::NaiveDate::from_ymd_opt(2026, 4, 1).unwrap();
         compute_route_speed_daily(&db, &agency, service_date)
@@ -2579,7 +2525,7 @@ mod tests {
             .unwrap();
 
         let dwell: Option<f64> = sqlx::query_scalar(
-            "SELECT avg_dwell_secs FROM route_speed_daily WHERE agency_id = '0' AND route_id = 'R1'",
+            "SELECT avg_dwell_secs FROM route_daily_stats WHERE feed_id = 0 AND route_id = 'R1'",
         )
         .fetch_one(&db.pool)
         .await
@@ -2598,48 +2544,73 @@ mod tests {
         let db = td.db;
         let agency = test_agency();
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         // S1: dwell = 30s, but appears 5 times due to repeated RT polls
-        for i in 0..5i64 {
+        let s1_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 1_000, 0).unwrap();
+        let s1_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 1_030, 0).unwrap();
+        for _ in 0..5i64 {
             sqlx::query(
                 "INSERT INTO stop_time_events
-                 (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-                 VALUES ('0','2026-04-01T08:00:00Z','T1','S1',1,1000,1030)",
+                 (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+                 VALUES (0, '2026-04-01T08:00:00Z', 'T1', 'S1', 1, $1, $2)",
             )
-            .execute(&db.pool).await.unwrap();
-            let _ = i;
+            .bind(s1_arr)
+            .bind(s1_dep)
+            .execute(&db.pool)
+            .await
+            .unwrap();
         }
         // S2: dwell = 20s, appears once
+        let s2_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 1_700, 0).unwrap();
+        let s2_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 1_720, 0).unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-             VALUES ('0','2026-04-01T08:10:00Z','T1','S2',2,1700,1720)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (0, '2026-04-01T08:10:00Z', 'T1', 'S2', 2, $1, $2)",
         )
-        .execute(&db.pool).await.unwrap();
+        .bind(s2_arr)
+        .bind(s2_dep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         // Without dedup: (30×5 + 20×1)/6 = 170/6 ≈ 28.3s — wrong
         // With dedup:    (30 + 20)/2       = 25.0s — correct
@@ -2649,9 +2620,11 @@ mod tests {
             .unwrap();
 
         let dwell: Option<f64> = sqlx::query_scalar(
-            "SELECT avg_dwell_secs FROM route_speed_daily WHERE agency_id = '0' AND route_id = 'R1'",
+            "SELECT avg_dwell_secs FROM route_daily_stats WHERE feed_id = 0 AND route_id = 'R1'",
         )
-        .fetch_one(&db.pool).await.unwrap();
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
 
         let dwell = dwell.expect("expected avg_dwell_secs to be Some");
         assert!(
@@ -2666,45 +2639,71 @@ mod tests {
         let db = td.db;
         let agency = test_agency();
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','Stop 1',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Stop 2',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
+        create_stop_time_events_partition(&db).await;
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'Stop 1', 45.50, -73.50), ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
         // S1: 1200s dwell (20 min anomaly) → should be capped to 300s
         // S2: 60s dwell → kept as-is
         // Expected avg: (300 + 60) / 2 = 180s
+        let s1_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 1_000, 0).unwrap();
+        let s1_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 2_200, 0).unwrap();
+        let s2_arr = chrono::DateTime::from_timestamp(1_775_376_000 + 4_000, 0).unwrap();
+        let s2_dep = chrono::DateTime::from_timestamp(1_775_376_000 + 4_060, 0).unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-             VALUES ('0','2026-04-01T08:00:00Z','T1','S1',1,1000,2200)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (0, '2026-04-01T08:00:00Z', 'T1', 'S1', 1, $1, $2)",
         )
-        .execute(&db.pool).await.unwrap();
+        .bind(s1_arr)
+        .bind(s1_dep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix, departure_time_unix)
-             VALUES ('0','2026-04-01T08:10:00Z','T1','S2',2,4000,4060)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (0, '2026-04-01T08:10:00Z', 'T1', 'S2', 2, $1, $2)",
         )
-        .execute(&db.pool).await.unwrap();
+        .bind(s2_arr)
+        .bind(s2_dep)
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         let service_date = chrono::NaiveDate::from_ymd_opt(2026, 4, 1).unwrap();
         compute_route_speed_daily(&db, &agency, service_date)
@@ -2712,9 +2711,11 @@ mod tests {
             .unwrap();
 
         let dwell: Option<f64> = sqlx::query_scalar(
-            "SELECT avg_dwell_secs FROM route_speed_daily WHERE agency_id = '0' AND route_id = 'R1'",
+            "SELECT avg_dwell_secs FROM route_daily_stats WHERE feed_id = 0 AND route_id = 'R1'",
         )
-        .fetch_one(&db.pool).await.unwrap();
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
 
         let dwell = dwell.expect("expected avg_dwell_secs to be Some");
         assert!(
@@ -3033,40 +3034,41 @@ mod tests {
         let td = test_utils::setup().await;
         let db = &td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        // feed_id=0 required by route_variants and route_variant_stops FKs
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&db.pool)
             .await
             .unwrap();
 
         // S1 and S2 are 0.01° apart in latitude ≈ 1111 m; S2 and S3 are 0.001° ≈ 111 m
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'First Stop',  45.500, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'First Stop',  45.500, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Middle Stop', 45.510, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Middle Stop', 45.510, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S3', 'Terminus',    45.511, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S3', 'Terminus',    45.511, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
 
         // One variant, direction 0, is_primary=true, trip_count=5
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 3, 5, true)",
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES (0, 'VAR1', 'R1', 0, 3, 5, true)",
         ).execute(&db.pool).await.unwrap();
 
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 1, 'S1')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 2, 'S2')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 3, 'S3')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 3, 'S3')")
             .execute(&db.pool)
             .await
             .unwrap();
@@ -3110,51 +3112,52 @@ mod tests {
         let td = test_utils::setup().await;
         let db = &td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        // feed_id=0 required by route_variants and route_variant_stops FKs
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&db.pool)
             .await
             .unwrap();
 
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SA', 'Alpha',  45.500, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('SA', 'Alpha',  45.500, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SB', 'Beta',   45.505, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('SB', 'Beta',   45.505, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SC', 'Gamma',  45.510, -73.50)")
+        sqlx::query("INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('SC', 'Gamma',  45.510, -73.50)")
             .execute(&db.pool)
             .await
             .unwrap();
 
         // VAR2 has fewer trips than VAR1 — should come second even though lexicographically first
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 3, 10, true),
-                    ('0', 'VAR2', 'R1', 0, 2,  3, false)",
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES (0, 'VAR1', 'R1', 0, 3, 10, true),
+                    (0, 'VAR2', 'R1', 0, 2,  3, false)",
         ).execute(&db.pool).await.unwrap();
 
         // VAR1: SA → SB → SC
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'SA')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 1, 'SA')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'SB')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 2, 'SB')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 3, 'SC')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 3, 'SC')")
             .execute(&db.pool)
             .await
             .unwrap();
 
         // VAR2: SA → SC (short turn, skips SB)
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR2', 1, 'SA')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR2', 1, 'SA')")
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR2', 2, 'SC')")
+        sqlx::query("INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR2', 2, 'SC')")
             .execute(&db.pool)
             .await
             .unwrap();
@@ -3210,29 +3213,53 @@ mod tests {
         let td = test_utils::setup().await;
         let db = &td.db;
 
-        // Insert scheduled speed first (needed by the JOIN)
+        // Prerequisites: feeds, agencies, routes, route_variants
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        // VAR_D0 → direction 0, VAR_D1 → direction 1
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 6.0, 1, 'now'),
-                    ('0', 'R1', 1, 5.0, 1, 'now')",
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES (0, 'VAR_D0', 'R1', 0, 2, 1, true),
+                    (0, 'VAR_D1', 'R1', 1, 2, 1, false)",
         )
         .execute(&db.pool)
         .await
         .unwrap();
 
-        for (date, dir, speed) in [
-            (weekday_date.as_str(), 0_i64, 5.0_f64),
-            (saturday_date.as_str(), 0, 6.0),
-            (sunday_date.as_str(), 0, 7.0),
-            (weekday_date.as_str(), 1, 4.0),
+        // Insert scheduled speed with new schema
+        sqlx::query(
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at)
+             VALUES (0, 'R1', 'VAR_D0', 6.0, 1, NOW()),
+                    (0, 'R1', 'VAR_D1', 5.0, 1, NOW())",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        // Insert actual speed into route_daily_stats with matching variant_ids
+        for (date, variant_id, speed) in [
+            (weekday_date.as_str(), "VAR_D0", 5.0_f64),
+            (saturday_date.as_str(), "VAR_D0", 6.0),
+            (sunday_date.as_str(), "VAR_D0", 7.0),
+            (weekday_date.as_str(), "VAR_D1", 4.0),
         ] {
             sqlx::query(
-                "INSERT INTO route_speed_daily
-                 (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, computed_at)
-                 VALUES ('0', 'R1', $1, $2, $3, 1, 'now')",
+                "INSERT INTO route_daily_stats
+                 (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, trips_run, trips_total, actual_speed_mps, computed_at)
+                 VALUES (0, 'R1', $1::DATE, $2, 0, 0, 0, 1, 1, $3, NOW())",
             )
             .bind(date)
-            .bind(dir)
+            .bind(variant_id)
             .bind(speed)
             .execute(&db.pool)
             .await
@@ -3283,11 +3310,32 @@ mod tests {
         let td = test_utils::setup().await;
         let db = &td.db;
 
+        // Prerequisites: feeds, agencies, routes, route_variants
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES (0, 'VAR_D0', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
         // Insert actual data only — no row in route_speed (no scheduled speed).
         sqlx::query(
-            "INSERT INTO route_speed_daily
-             (agency_id, route_id, service_date, direction_id, actual_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', $1, 0, 8.0, 1, 'now')",
+            "INSERT INTO route_daily_stats
+             (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, trips_run, trips_total, actual_speed_mps, computed_at)
+             VALUES (0, 'R1', $1::DATE, 'VAR_D0', 0, 0, 0, 1, 1, 8.0, NOW())",
         )
         .bind(&weekday_date)
         .execute(&db.pool)
@@ -3399,9 +3447,23 @@ mod tests {
         let td = test_utils::setup().await;
         let db = &td.db;
 
+        // Prerequisites: feeds, agencies, routes
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
         sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at)
-             VALUES ('0', 'R1', 0, 6.0, 1, 'now')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, trip_count, computed_at)
+             VALUES (0, 'R1', 'VAR1', 6.0, 1, NOW())",
         ).execute(&db.pool).await.unwrap();
 
         for (date, variant_id, speed) in [
@@ -3410,9 +3472,9 @@ mod tests {
             (weekday_date.as_str(), "VAR2", 4.0),
         ] {
             sqlx::query(
-                "INSERT INTO route_speed_daily
-                 (agency_id, route_id, service_date, direction_id, variant_id, actual_speed_mps, trip_count, computed_at)
-                 VALUES ('0', 'R1', $1, 0, $2, $3, 1, 'now')",
+                "INSERT INTO route_daily_stats
+                 (feed_id, route_id, service_date, variant_id, on_time_stops, total_stops, skipped_stops, trips_run, trips_total, actual_speed_mps, computed_at)
+                 VALUES (0, 'R1', $1::DATE, $2, 0, 0, 0, 1, 1, $3, NOW())",
             )
             .bind(date)
             .bind(variant_id)
@@ -3456,47 +3518,48 @@ mod tests {
         let td = test_utils::setup().await;
         let db = td.db;
 
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S1','First Stop',45.50,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0','S2','Last Stop',45.51,-73.50)")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S1',1,'08:00:00','08:00:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO scheduled_stops VALUES ('0','T1','S2',2,'08:10:00','08:10:00')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+        seed_base(&db).await;
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 2, 1, true)",
-        ).execute(&db.pool).await.unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
-            .execute(&db.pool)
-            .await
-            .unwrap();
+            "INSERT INTO stops (onestop_id, name, lat, lon) \
+             VALUES ('S1', 'First Stop', 45.50, -73.50), ('S2', 'Last Stop', 45.51, -73.50)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) \
+             VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_id, stop_sequence) \
+             VALUES (0, 'VAR1', 'S1', 1), (0, 'VAR1', 'S2', 2)",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) \
+             VALUES (0, 'T1', 'VAR1', 'WD')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time) \
+             VALUES (0, 'T1', 'S1', 1, '08:00:00', '08:00:00'), \
+                    (0, 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+        )
+        .execute(&db.pool)
+        .await
+        .unwrap();
 
         compute_route_speed(&db, &test_agency()).await.unwrap();
 
         let last_stop_name: Option<String> = sqlx::query_scalar(
-            "SELECT last_stop_name FROM route_speed WHERE agency_id = '0' AND route_id = 'R1' AND direction_id = 0",
+            "SELECT last_stop_name FROM route_speed WHERE feed_id = 0 AND route_id = 'R1' AND variant_id = 'VAR1'",
         )
         .fetch_one(&db.pool)
         .await

--- a/crates/core/src/transitland/mod.rs
+++ b/crates/core/src/transitland/mod.rs
@@ -151,7 +151,9 @@ impl TransitlandClient {
         let body: StopsResponse = response.json().await?;
         Ok(body.stops.into_iter().next().map(|r| {
             let stop_id = StopId::from(r.onestop_id);
-            let station_id = r.parent.map(|s| StationId::from(s.onestop_id));
+            let station_id = r
+                .parent
+                .and_then(|parent| parent.onestop_id.map(StationId::from));
             (stop_id, station_id)
         }))
     }
@@ -162,7 +164,7 @@ impl TransitlandClient {
     ) -> anyhow::Result<std::collections::HashMap<String, (StopId, Option<StationId>)>> {
         let url = format!("{}/stops.json", self.base_url);
         let mut after = None;
-        let mut resolved = std::collections::HashMap::new();
+        let mut records = Vec::new();
 
         loop {
             let request = self
@@ -176,21 +178,37 @@ impl TransitlandClient {
             let response = self.apply_auth(request).send().await?.error_for_status()?;
             let body: StopsResponse = response.json().await?;
             after = body.meta.and_then(|meta| meta.after);
-
-            for record in body.stops {
-                let station_id = record
-                    .parent
-                    .map(|station| StationId::from(station.onestop_id));
-                resolved.insert(
-                    record.stop_id,
-                    (StopId::from(record.onestop_id), station_id),
-                );
-            }
+            records.extend(body.stops);
 
             if after.is_none() {
-                return Ok(resolved);
+                break;
             }
         }
+
+        let onestop_ids_by_stop_id: std::collections::HashMap<_, _> = records
+            .iter()
+            .map(|record| (record.stop_id.clone(), record.onestop_id.clone()))
+            .collect();
+
+        Ok(records
+            .into_iter()
+            .map(|record| {
+                let station_id = record.parent.and_then(|parent| {
+                    parent.onestop_id.or_else(|| {
+                        parent
+                            .stop_id
+                            .and_then(|stop_id| onestop_ids_by_stop_id.get(&stop_id).cloned())
+                    })
+                });
+                (
+                    record.stop_id,
+                    (
+                        StopId::from(record.onestop_id),
+                        station_id.map(StationId::from),
+                    ),
+                )
+            })
+            .collect())
     }
 }
 
@@ -272,7 +290,7 @@ struct StopRecord {
     stop_id: String,
     onestop_id: String,
     #[serde(default, alias = "parent_station")]
-    parent: Option<StationRecord>,
+    parent: Option<ParentStopRef>,
 }
 
 #[derive(serde::Deserialize)]
@@ -281,8 +299,11 @@ struct PaginationMeta {
 }
 
 #[derive(serde::Deserialize)]
-struct StationRecord {
-    onestop_id: String,
+struct ParentStopRef {
+    #[serde(default)]
+    onestop_id: Option<String>,
+    #[serde(default)]
+    stop_id: Option<String>,
 }
 
 fn unique_feed_ids(operators: &[OperatorRecord]) -> Vec<(String, String)> {
@@ -445,6 +466,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_stops_for_feed_resolves_parent_by_stop_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param("feed_onestop_id", "f-rem"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stops": [
+                    {
+                        "stop_id": "STA_QUAI_01",
+                        "onestop_id": "s-platform",
+                        "parent": {
+                            "id": 2242740962_u64,
+                            "stop_id": "ST_DUQ_1",
+                            "stop_name": "Station Du Quartier"
+                        }
+                    },
+                    {
+                        "stop_id": "ST_DUQ_1",
+                        "onestop_id": "s-station",
+                        "parent": null
+                    }
+                ],
+                "meta": null
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let result = client.resolve_stops_for_feed("f-rem").await.unwrap();
+
+        assert_eq!(
+            result.get("STA_QUAI_01"),
+            Some(&(
+                StopId::from("s-platform"),
+                Some(StationId::from("s-station"))
+            ))
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_stops_for_feed_follows_pagination() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -456,7 +517,7 @@ mod tests {
                 "stops": [{
                     "stop_id": "first",
                     "onestop_id": "s-first",
-                    "parent": null
+                    "parent": {"stop_id": "second"}
                 }],
                 "meta": {"after": 42}
             })))
@@ -483,7 +544,10 @@ mod tests {
         let client = client_for(&server);
         let result = client.resolve_stops_for_feed("f-test").await.unwrap();
 
-        assert_eq!(result.get("first"), Some(&(StopId::from("s-first"), None)));
+        assert_eq!(
+            result.get("first"),
+            Some(&(StopId::from("s-first"), Some(StationId::from("s-second"))))
+        );
         assert_eq!(
             result.get("second"),
             Some(&(StopId::from("s-second"), None))

--- a/crates/core/src/transitland/mod.rs
+++ b/crates/core/src/transitland/mod.rs
@@ -151,9 +151,46 @@ impl TransitlandClient {
         let body: StopsResponse = response.json().await?;
         Ok(body.stops.into_iter().next().map(|r| {
             let stop_id = StopId::from(r.onestop_id);
-            let station_id = r.parent_station.map(|s| StationId::from(s.onestop_id));
+            let station_id = r.parent.map(|s| StationId::from(s.onestop_id));
             (stop_id, station_id)
         }))
+    }
+
+    pub async fn resolve_stops_for_feed(
+        &self,
+        feed_onestop_id: &str,
+    ) -> anyhow::Result<std::collections::HashMap<String, (StopId, Option<StationId>)>> {
+        let url = format!("{}/stops.json", self.base_url);
+        let mut after = None;
+        let mut resolved = std::collections::HashMap::new();
+
+        loop {
+            let request = self
+                .http
+                .get(&url)
+                .query(&[("feed_onestop_id", feed_onestop_id), ("limit", "1000")]);
+            let request = match after {
+                Some(cursor) => request.query(&[("after", cursor)]),
+                None => request,
+            };
+            let response = self.apply_auth(request).send().await?.error_for_status()?;
+            let body: StopsResponse = response.json().await?;
+            after = body.meta.and_then(|meta| meta.after);
+
+            for record in body.stops {
+                let station_id = record
+                    .parent
+                    .map(|station| StationId::from(station.onestop_id));
+                resolved.insert(
+                    record.stop_id,
+                    (StopId::from(record.onestop_id), station_id),
+                );
+            }
+
+            if after.is_none() {
+                return Ok(resolved);
+            }
+        }
     }
 }
 
@@ -225,12 +262,22 @@ struct RouteRecord {
 #[derive(serde::Deserialize)]
 struct StopsResponse {
     stops: Vec<StopRecord>,
+    #[serde(default)]
+    meta: Option<PaginationMeta>,
 }
 
 #[derive(serde::Deserialize)]
 struct StopRecord {
+    #[serde(default)]
+    stop_id: String,
     onestop_id: String,
-    parent_station: Option<StationRecord>,
+    #[serde(default, alias = "parent_station")]
+    parent: Option<StationRecord>,
+}
+
+#[derive(serde::Deserialize)]
+struct PaginationMeta {
+    after: Option<i64>,
 }
 
 #[derive(serde::Deserialize)]
@@ -255,7 +302,7 @@ fn unique_feed_ids(operators: &[OperatorRecord]) -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn client_for(server: &MockServer) -> TransitlandClient {
@@ -354,6 +401,118 @@ mod tests {
                 Some(StationId::from("s-f25e-berri"))
             ))
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_stops_for_feed_returns_map() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param("feed_onestop_id", "f-f25d-stm"))
+            .and(query_param("limit", "1000"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stops": [
+                    {
+                        "stop_id": "56789",
+                        "onestop_id": "s-f25ek-berrinord",
+                        "parent": {"onestop_id": "s-f25e-berri"}
+                    },
+                    {
+                        "stop_id": "11111",
+                        "onestop_id": "s-f25ek-somewhere",
+                        "parent": null
+                    }
+                ],
+                "meta": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let result = client.resolve_stops_for_feed("f-f25d-stm").await.unwrap();
+
+        assert_eq!(
+            result.get("56789"),
+            Some(&(
+                StopId::from("s-f25ek-berrinord"),
+                Some(StationId::from("s-f25e-berri"))
+            ))
+        );
+        assert_eq!(
+            result.get("11111"),
+            Some(&(StopId::from("s-f25ek-somewhere"), None))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_stops_for_feed_follows_pagination() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param("feed_onestop_id", "f-test"))
+            .and(query_param("limit", "1000"))
+            .and(query_param_is_missing("after"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stops": [{
+                    "stop_id": "first",
+                    "onestop_id": "s-first",
+                    "parent": null
+                }],
+                "meta": {"after": 42}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param("feed_onestop_id", "f-test"))
+            .and(query_param("limit", "1000"))
+            .and(query_param("after", "42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stops": [{
+                    "stop_id": "second",
+                    "onestop_id": "s-second",
+                    "parent": null
+                }],
+                "meta": {}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let result = client.resolve_stops_for_feed("f-test").await.unwrap();
+
+        assert_eq!(result.get("first"), Some(&(StopId::from("s-first"), None)));
+        assert_eq!(
+            result.get("second"),
+            Some(&(StopId::from("s-second"), None))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_stops_for_feed_propagates_later_page_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param_is_missing("after"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stops": [],
+                "meta": {"after": 42}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/stops.json"))
+            .and(query_param("after", "42"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let error = client.resolve_stops_for_feed("f-test").await.unwrap_err();
+
+        assert!(error.to_string().contains("429 Too Many Requests"));
     }
 
     // ── Discover Feeds ────────────────────────────────────────────────────────

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -12,7 +12,7 @@ use mobilispect_core::db::feeds::{load_feed_options, store_discovered_feeds};
 use mobilispect_core::ids::{FeedId, RouteId};
 use mobilispect_core::on_time_performance::{RouteSummary, RouteTrend, route_summary, route_trend};
 use mobilispect_core::service_frequency::{
-    RouteHeadwayRow, RouteHourlyFrequency, route_headways, route_hourly_frequency,
+    RouteHourlyFrequency, ScheduleGroup, group_by_span, route_headways, route_hourly_frequency,
 };
 use mobilispect_core::speed_analysis::{
     RouteClass, RouteSpeedCard, RouteSpeedDetailDirection, RouteSpeedSummary, assign_indices,
@@ -366,7 +366,7 @@ pub async fn api_route_speed(
 #[template(path = "pages/frequency.html")]
 struct FrequencyTemplate {
     region_name: String,
-    rows: Vec<RouteHeadwayRow>,
+    groups: Vec<ScheduleGroup>,
     agencies: Vec<(String, String)>,
     active_agency: String,
 }
@@ -374,7 +374,7 @@ struct FrequencyTemplate {
 #[derive(Template)]
 #[template(path = "partials/frequency_content.html")]
 struct FrequencyContentTemplate {
-    rows: Vec<RouteHeadwayRow>,
+    groups: Vec<ScheduleGroup>,
     agencies: Vec<(String, String)>,
     active_agency: String,
 }
@@ -407,10 +407,11 @@ pub async fn frequency_page(
                 .into_response();
         }
     };
+    let groups = group_by_span(rows);
 
     if headers.contains_key("hx-request") {
         let tmpl = FrequencyContentTemplate {
-            rows,
+            groups,
             agencies,
             active_agency,
         };
@@ -428,7 +429,7 @@ pub async fn frequency_page(
     } else {
         let tmpl = FrequencyTemplate {
             region_name: region_name(&state).await,
-            rows,
+            groups,
             agencies,
             active_agency,
         };

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -8,7 +8,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::web::{AppState, SetupState};
-use mobilispect_core::db::feeds::store_discovered_feeds;
+use mobilispect_core::db::feeds::{load_feed_options, store_discovered_feeds};
 use mobilispect_core::ids::{FeedId, RouteId};
 use mobilispect_core::on_time_performance::{RouteSummary, RouteTrend, route_summary, route_trend};
 use mobilispect_core::service_frequency::{
@@ -259,7 +259,7 @@ pub async fn speed_page(
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
 
-    let agencies: Vec<(String, String)> = vec![];
+    let agencies = load_feed_options(&state.db.pool).await.unwrap_or_default();
     let active_agency = params
         .agency
         .filter(|s| agencies.iter().any(|(id, _)| id == s))
@@ -386,7 +386,7 @@ pub async fn frequency_page(
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
 
-    let agencies: Vec<(String, String)> = vec![];
+    let agencies = load_feed_options(&state.db.pool).await.unwrap_or_default();
     let active_agency = params
         .agency
         .filter(|s| agencies.iter().any(|(id, _)| id == s))

--- a/crates/server/src/web/handlers.rs
+++ b/crates/server/src/web/handlers.rs
@@ -678,47 +678,50 @@ mod e2e_tests {
     #[tokio::test]
     async fn route_speed_detail_returns_200_with_direction_name() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&td.db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Downtown')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Main St',  45.50, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Downtown', 45.51, -73.50)")
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Main St', 45.50, -73.50)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 2, 1, true)",
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Downtown', 45.51, -73.50)",
         )
-        .execute(&td.db.pool).await.unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 1, 'S1')",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 2, 'S2')",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
 
         let state = AppState {
             db: td.db,
@@ -791,37 +794,23 @@ mod e2e_tests {
     #[tokio::test]
     async fn speed_page_shows_classification_badge_for_rapid_route() {
         let td = test_utils::setup().await;
-        // R1: two stops ~1111 m apart (0.01° lat). Single segment → avg = 1111 m → Rapid.
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        // R1: avg_stop_spacing_m = 1111 m → Rapid.
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&td.db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Terminus')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'First',   45.500, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Terminus', 45.510, -73.50)")
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
-        )
-        .execute(&td.db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO route_speed (agency_id, route_id, direction_id, scheduled_speed_mps, trip_count, computed_at) VALUES ('0', 'R1', 0, 8.0, 1, '2026-01-01T00:00:00Z')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) VALUES (0, 'R1', 'VAR1', 8.0, 1111.0, 1, NOW())",
         )
         .execute(&td.db.pool)
         .await
@@ -862,77 +851,42 @@ mod e2e_tests {
     async fn speed_page_filters_by_class_local() {
         let td = test_utils::setup().await;
 
-        // Local route: two stops ~333 m apart (0.003° lat × 111 km/°) → avg < 500 m → Local
-        sqlx::query("INSERT INTO routes VALUES ('0', 'RL', 'LocalX', 'Local Route', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&td.db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'TL', 'RL', 'WD', 0, 'End Local')")
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SL1', 'Local A', 45.500, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SL2', 'Local B', 45.503, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'TL', 'SL1', 1, '08:00:00', '08:00:00')",
-        )
-        .execute(&td.db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'TL', 'SL2', 2, '08:05:00', '08:05:00')",
-        )
-        .execute(&td.db.pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'RL', 0, 5.0, 333.0, 1, '2026-01-01T00:00:00Z')",
-        )
-            .execute(&td.db.pool).await.unwrap();
 
-        // Rapid route: two stops ~1111 m apart (0.010° lat) → avg 500–1500 m → Rapid
-        sqlx::query("INSERT INTO routes VALUES ('0', 'RR', 'RapidX', 'Rapid Route', 3)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'TR', 'RR', 'WD', 0, 'End Rapid')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SR1', 'Rapid A', 45.500, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'SR2', 'Rapid B', 45.510, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
+        // Local route: avg_stop_spacing_m = 333 m → Local
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'TR', 'SR1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('RL', 'a', 'LocalX', 'Local Route', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'TR', 'SR2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) VALUES (0, 'RL', 'VARL', 5.0, 333.0, 1, NOW())",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+
+        // Rapid route: avg_stop_spacing_m = 1111 m → Rapid
+        sqlx::query(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('RR', 'a', 'RapidX', 'Rapid Route', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_speed
-             (agency_id, route_id, direction_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at)
-             VALUES ('0', 'RR', 0, 8.0, 1111.0, 1, '2026-01-01T00:00:00Z')",
+            "INSERT INTO route_speed (feed_id, route_id, variant_id, scheduled_speed_mps, avg_stop_spacing_m, trip_count, computed_at) VALUES (0, 'RR', 'VARR', 8.0, 1111.0, 1, NOW())",
         )
-            .execute(&td.db.pool).await.unwrap();
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
 
         let state = AppState {
             db: td.db,
@@ -1083,47 +1037,50 @@ mod e2e_tests {
     async fn route_speed_detail_shows_classification_badge() {
         let td = test_utils::setup().await;
         // Two stops ~1111 m apart → avg spacing 1111 m → Rapid
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&td.db.pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Downtown')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Main St',  45.50, -73.50)")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Downtown', 45.51, -73.50)")
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '1', 'Route 1', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Main St', 45.50, -73.50)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO route_variants (agency_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
-             VALUES ('0', 'VAR1', 'R1', 0, 2, 1, true)",
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Downtown', 45.51, -73.50)",
         )
-        .execute(&td.db.pool).await.unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 1, 'S1')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO route_variant_stops VALUES ('0', 'VAR1', 2, 'S2')")
-            .execute(&td.db.pool)
-            .await
-            .unwrap();
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 1, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 1, 'S1')",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variant_stops (feed_id, variant_id, stop_sequence, stop_id) VALUES (0, 'VAR1', 2, 'S2')",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
 
         let state = AppState {
             db: td.db,
@@ -1240,12 +1197,40 @@ mod e2e_tests {
     #[tokio::test]
     async fn schedule_page_renders_route_schedule_cards() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '10', 'Route 10', 3)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 3, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Stop 2', 45.51, -73.50)",
         )
         .execute(&td.db.pool)
         .await
@@ -1255,23 +1240,29 @@ mod e2e_tests {
             ("T2", "06:10:00", "06:40:00"),
             ("T3", "06:30:00", "07:00:00"),
         ] {
-            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', 0, 'Downtown')")
-                .bind(trip_id)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
-                .bind(trip_id)
-                .bind(dep_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
-                .bind(trip_id)
-                .bind(arr_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) VALUES (0, $1, 'VAR1', 'WD')",
+            )
+            .bind(trip_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 1, 'S1', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 2, 'S2', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
         }
 
         let state = AppState {
@@ -1309,12 +1300,40 @@ mod e2e_tests {
     #[tokio::test]
     async fn schedule_page_uses_top_decile_headway_instead_of_minimum() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '10', 'Route 10', 3)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 21, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Stop 2', 45.51, -73.50)",
         )
         .execute(&td.db.pool)
         .await
@@ -1330,23 +1349,29 @@ mod e2e_tests {
             );
             let arr_secs = departure_secs + 30 * 60;
             let arr_time = format!("{:02}:{:02}:00", arr_secs / 3600, (arr_secs % 3600) / 60);
-            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', 0, 'Downtown')")
-                .bind(&trip_id)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
-                .bind(&trip_id)
-                .bind(&dep_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
-                .bind(&trip_id)
-                .bind(&arr_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) VALUES (0, $1, 'VAR1', 'WD')",
+            )
+            .bind(&trip_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 1, 'S1', $2, $2)",
+            )
+            .bind(&trip_id)
+            .bind(&dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 2, 'S2', $2, $2)",
+            )
+            .bind(&trip_id)
+            .bind(&arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
 
             departure_secs += if i == 0 { 60 } else { 10 * 60 };
         }
@@ -1388,19 +1413,47 @@ mod e2e_tests {
     #[tokio::test]
     async fn schedule_page_computes_headways_within_each_service_id() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
             .execute(&td.db.pool)
             .await
             .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '10', 'Route 10', 3)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
         for service_id in ["WD1", "WD2"] {
             sqlx::query(
-                "INSERT INTO calendar VALUES ('0', $1, true, true, true, true, true, false, false)",
+                "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, $1, true, true, true, true, true, false, false)",
             )
             .bind(service_id)
             .execute(&td.db.pool)
             .await
             .unwrap();
         }
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 6, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
 
         for (trip_id, service_id, dep_time, arr_time) in [
             ("T1", "WD1", "06:00:00", "06:30:00"),
@@ -1410,24 +1463,30 @@ mod e2e_tests {
             ("T5", "WD2", "06:11:00", "06:41:00"),
             ("T6", "WD2", "06:21:00", "06:51:00"),
         ] {
-            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', $2, 0, 'Downtown')")
-                .bind(trip_id)
-                .bind(service_id)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
-                .bind(trip_id)
-                .bind(dep_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
-                .bind(trip_id)
-                .bind(arr_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) VALUES (0, $1, 'VAR1', $2)",
+            )
+            .bind(trip_id)
+            .bind(service_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 1, 'S1', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 2, 'S2', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
         }
 
         let state = AppState {
@@ -1464,40 +1523,81 @@ mod e2e_tests {
     #[tokio::test]
     async fn schedule_page_combines_directions_into_one_route_card() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '10', 'Route 10', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
-        for (direction_id, trip_id, dep_time, arr_time) in [
-            (0, "T1", "06:00:00", "06:30:00"),
-            (0, "T2", "06:10:00", "06:40:00"),
-            (1, "T3", "06:05:00", "06:35:00"),
-            (1, "T4", "06:15:00", "06:45:00"),
+        sqlx::query(
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        // Two variants with different direction_ids for the same route
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VARA', 'R1', 0, 2, 2, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VARB', 'R1', 1, 2, 2, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Stop 2', 45.51, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        for (variant_id, trip_id, dep_time, arr_time) in [
+            ("VARA", "T1", "06:00:00", "06:30:00"),
+            ("VARA", "T2", "06:10:00", "06:40:00"),
+            ("VARB", "T3", "06:05:00", "06:35:00"),
+            ("VARB", "T4", "06:15:00", "06:45:00"),
         ] {
-            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', 'WD', $2, 'Downtown')")
-                .bind(trip_id)
-                .bind(direction_id)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
-                .bind(trip_id)
-                .bind(dep_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
-                .bind(trip_id)
-                .bind(arr_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) VALUES (0, $1, $2, 'WD')",
+            )
+            .bind(trip_id)
+            .bind(variant_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 1, 'S1', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 2, 'S2', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
         }
 
         let state = AppState {
@@ -1531,18 +1631,46 @@ mod e2e_tests {
     #[tokio::test]
     async fn schedule_page_renders_saturday_column_when_saturday_service_exists() {
         let td = test_utils::setup().await;
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '10', 'Route 10', 3)")
+        sqlx::query("INSERT INTO feeds (id, gtfs_static_url) VALUES (0, 'http://test')")
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO agencies (onestop_id, name) VALUES ('a', 'Agency')")
             .execute(&td.db.pool)
             .await
             .unwrap();
         sqlx::query(
-            "INSERT INTO calendar VALUES ('0', 'WD', true, true, true, true, true, false, false)",
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type) VALUES ('R1', 'a', '10', 'Route 10', 3)",
         )
         .execute(&td.db.pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO calendar VALUES ('0', 'SAT', false, false, false, false, false, true, false)",
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, 'WD', true, true, true, true, true, false, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO services (feed_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES (0, 'SAT', false, false, false, false, false, true, false)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary) VALUES (0, 'VAR1', 'R1', 0, 2, 4, true)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S1', 'Stop 1', 45.50, -73.50)",
+        )
+        .execute(&td.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon) VALUES ('S2', 'Stop 2', 45.51, -73.50)",
         )
         .execute(&td.db.pool)
         .await
@@ -1554,24 +1682,30 @@ mod e2e_tests {
             ("T3", "SAT", "09:00:00", "09:30:00"),
             ("T4", "SAT", "09:20:00", "09:50:00"),
         ] {
-            sqlx::query("INSERT INTO trips VALUES ('0', $1, 'R1', $2, 0, 'Downtown')")
-                .bind(trip_id)
-                .bind(service_id)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S1', 1, $2, $2)")
-                .bind(trip_id)
-                .bind(dep_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
-            sqlx::query("INSERT INTO scheduled_stops VALUES ('0', $1, 'S2', 2, $2, $2)")
-                .bind(trip_id)
-                .bind(arr_time)
-                .execute(&td.db.pool)
-                .await
-                .unwrap();
+            sqlx::query(
+                "INSERT INTO trips (feed_id, trip_id, variant_id, service_id) VALUES (0, $1, 'VAR1', $2)",
+            )
+            .bind(trip_id)
+            .bind(service_id)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 1, 'S1', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(dep_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO scheduled_stops (feed_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time) VALUES (0, $1, 2, 'S2', $2, $2)",
+            )
+            .bind(trip_id)
+            .bind(arr_time)
+            .execute(&td.db.pool)
+            .await
+            .unwrap();
         }
 
         let state = AppState {
@@ -1615,7 +1749,11 @@ mod e2e_tests {
             region: Arc::new(RwLock::new(Some("Test Region".to_string()))),
             setup_state: Arc::new(tokio::sync::Mutex::new(SetupState::Idle)),
         };
-        let app = build_router(state);
+        let app = build_router(state.clone()).merge(
+            axum::Router::new()
+                .route("/health", axum::routing::get(health_check))
+                .with_state(state),
+        );
 
         let response = app
             .oneshot(

--- a/crates/server/templates/pages/frequency.html
+++ b/crates/server/templates/pages/frequency.html
@@ -118,7 +118,7 @@
 /* Accordion */
 .schedule-accordion {
   margin-bottom: 1.25rem;
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--line-soft);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -129,21 +129,14 @@
   justify-content: space-between;
   padding: 0.875rem 1.25rem;
   cursor: pointer;
-  background: var(--bg-subtle);
+  background: var(--surface-muted);
   user-select: none;
   gap: 1rem;
 }
 .schedule-accordion summary::-webkit-details-marker { display: none; }
 .schedule-accordion summary:focus-visible {
-  outline: 2px solid var(--cinn);
+  outline: 2px solid var(--civic-red);
   outline-offset: -2px;
-}
-.schedule-accordion__title {
-  font-family: 'Fira Code', monospace;
-  font-size: 0.68rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--cinn);
 }
 .schedule-accordion__meta {
   display: flex;
@@ -153,12 +146,12 @@
 .schedule-accordion__count {
   font-family: 'Jost', sans-serif;
   font-size: 0.75rem;
-  color: var(--muted);
+  color: var(--ink-500);
 }
 .accordion-chevron {
   transition: transform 0.2s ease;
   flex-shrink: 0;
-  color: var(--dim);
+  color: var(--ink-400);
 }
 .schedule-accordion[open] .accordion-chevron {
   transform: rotate(180deg);

--- a/crates/server/templates/pages/frequency.html
+++ b/crates/server/templates/pages/frequency.html
@@ -115,6 +115,53 @@
     grid-template-columns: 1fr;
   }
 }
+/* Accordion */
+.schedule-accordion {
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.schedule-accordion summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  cursor: pointer;
+  background: var(--bg-subtle);
+  user-select: none;
+  gap: 1rem;
+}
+.schedule-accordion summary::-webkit-details-marker { display: none; }
+.schedule-accordion__title {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--cinn);
+}
+.schedule-accordion__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.schedule-accordion__count {
+  font-family: 'Jost', sans-serif;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.accordion-chevron {
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+  color: var(--dim);
+}
+.schedule-accordion[open] .accordion-chevron {
+  transform: rotate(180deg);
+}
+.schedule-accordion__body {
+  padding: 1rem;
+}
 </style>
 {% endblock %}
 
@@ -123,7 +170,7 @@
   <div class="page-header">
     <div>
       <h1 class="page-title">Route Schedule</h1>
-      <p class="page-subtitle">Routes ranked by scheduled headway, with service span and day-type patterns</p>
+      <p class="page-subtitle">Routes grouped by service pattern and ranked by frequency within each group</p>
     </div>
   </div>
   <span id="freq-loading"

--- a/crates/server/templates/pages/frequency.html
+++ b/crates/server/templates/pages/frequency.html
@@ -134,6 +134,10 @@
   gap: 1rem;
 }
 .schedule-accordion summary::-webkit-details-marker { display: none; }
+.schedule-accordion summary:focus-visible {
+  outline: 2px solid var(--cinn);
+  outline-offset: -2px;
+}
 .schedule-accordion__title {
   font-family: 'Fira Code', monospace;
   font-size: 0.68rem;

--- a/crates/server/templates/partials/frequency_content.html
+++ b/crates/server/templates/partials/frequency_content.html
@@ -24,7 +24,7 @@
   {% for group in &groups %}
   <details class="schedule-accordion" open>
     <summary>
-      <span class="schedule-accordion__title">{{ group.title }}</span>
+      <span class="section-label">{{ group.title }}</span>
       <div class="schedule-accordion__meta">
         <span class="schedule-accordion__count">{% if group.rows.len() == 1 %}1 route{% else %}{{ group.rows.len() }} routes{% endif %}</span>
         <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/crates/server/templates/partials/frequency_content.html
+++ b/crates/server/templates/partials/frequency_content.html
@@ -23,10 +23,10 @@
   {% else %}
   {% for group in &groups %}
   <details class="schedule-accordion" open>
-    <summary class="schedule-accordion__summary">
+    <summary>
       <span class="schedule-accordion__title">{{ group.title }}</span>
       <div class="schedule-accordion__meta">
-        <span class="schedule-accordion__count">{{ group.rows.len() }} routes</span>
+        <span class="schedule-accordion__count">{% if group.rows.len() == 1 %}1 route{% else %}{{ group.rows.len() }} routes{% endif %}</span>
         <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>

--- a/crates/server/templates/partials/frequency_content.html
+++ b/crates/server/templates/partials/frequency_content.html
@@ -18,11 +18,12 @@
     {% endfor %}
   </div>
 
-  {% if rows.is_empty() %}
+  {% if groups.is_empty() %}
   <div class="empty-state">No schedule data available. Routes appear once GTFS schedule data has been ingested.</div>
   {% else %}
   <div class="schedule-grid">
-    {% for (i, row) in rows.iter().enumerate() %}
+    {% for group in &groups %}
+    {% for (i, row) in group.rows.iter().enumerate() %}
     <div class="card schedule-card">
       <a href="/schedule/{{ row.feed_id }}/{{ row.route_id }}" class="schedule-card__header" style="display:flex;text-decoration:none;color:inherit;">
         <div>
@@ -61,6 +62,7 @@
         {% endif %}
       </div>
     </div>
+    {% endfor %}
     {% endfor %}
   </div>
   {% endif %}

--- a/crates/server/templates/partials/frequency_content.html
+++ b/crates/server/templates/partials/frequency_content.html
@@ -21,49 +21,62 @@
   {% if groups.is_empty() %}
   <div class="empty-state">No schedule data available. Routes appear once GTFS schedule data has been ingested.</div>
   {% else %}
-  <div class="schedule-grid">
-    {% for group in &groups %}
-    {% for (i, row) in group.rows.iter().enumerate() %}
-    <div class="card schedule-card">
-      <a href="/schedule/{{ row.feed_id }}/{{ row.route_id }}" class="schedule-card__header" style="display:flex;text-decoration:none;color:inherit;">
-        <div>
-          <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
-          <div class="schedule-card__name">{{ row.long_name }}</div>
+  {% for group in &groups %}
+  <details class="schedule-accordion" open>
+    <summary class="schedule-accordion__summary">
+      <span class="schedule-accordion__title">{{ group.title }}</span>
+      <div class="schedule-accordion__meta">
+        <span class="schedule-accordion__count">{{ group.rows.len() }} routes</span>
+        <svg class="accordion-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+    </summary>
+    <div class="schedule-accordion__body">
+      <div class="schedule-grid">
+        {% for (i, row) in group.rows.iter().enumerate() %}
+        <div class="card schedule-card">
+          <a href="/schedule/{{ row.feed_id }}/{{ row.route_id }}" class="schedule-card__header" style="display:flex;text-decoration:none;color:inherit;">
+            <div>
+              <div class="route-id">{{ i + 1 }}. {{ row.short_name }}</div>
+              <div class="schedule-card__name">{{ row.long_name }}</div>
+            </div>
+            <span style="margin-left:auto;font-size:0.72rem;color:var(--link-blue);white-space:nowrap;align-self:center;">Details →</span>
+          </a>
+          <div class="schedule-card__days">
+            {% if row.weekday_headway_mins.is_some() %}
+            <div class="day-col">
+              <div class="day-col__hdr">Weekday</div>
+              <div class="spacing-stat-num spacing-{{ row.weekday_badge_variant() }}">{{ row.weekday_display() }}</div>
+              <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.weekday_top_decile_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.weekday_max_headway_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.weekday_service_span_display() }}</span></div>
+            </div>
+            {% endif %}
+            {% if row.saturday_headway_mins.is_some() %}
+            <div class="day-col">
+              <div class="day-col__hdr">Saturday</div>
+              <div class="spacing-stat-num spacing-{{ row.saturday_badge_variant() }}">{{ row.saturday_display() }}</div>
+              <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.saturday_top_decile_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.saturday_max_headway_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.saturday_service_span_display() }}</span></div>
+            </div>
+            {% endif %}
+            {% if row.sunday_headway_mins.is_some() %}
+            <div class="day-col">
+              <div class="day-col__hdr">Sunday</div>
+              <div class="spacing-stat-num spacing-{{ row.sunday_badge_variant() }}">{{ row.sunday_display() }}</div>
+              <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.sunday_top_decile_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.sunday_max_headway_display() }}</span></div>
+              <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.sunday_service_span_display() }}</span></div>
+            </div>
+            {% endif %}
+          </div>
         </div>
-        <span style="margin-left:auto;font-size:0.72rem;color:var(--link-blue);white-space:nowrap;align-self:center;">Details →</span>
-      </a>
-      <div class="schedule-card__days">
-        {% if row.weekday_headway_mins.is_some() %}
-        <div class="day-col">
-          <div class="day-col__hdr">Weekday</div>
-          <div class="spacing-stat-num spacing-{{ row.weekday_badge_variant() }}">{{ row.weekday_display() }}</div>
-          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.weekday_top_decile_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.weekday_max_headway_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.weekday_service_span_display() }}</span></div>
-        </div>
-        {% endif %}
-        {% if row.saturday_headway_mins.is_some() %}
-        <div class="day-col">
-          <div class="day-col__hdr">Saturday</div>
-          <div class="spacing-stat-num spacing-{{ row.saturday_badge_variant() }}">{{ row.saturday_display() }}</div>
-          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.saturday_top_decile_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.saturday_max_headway_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.saturday_service_span_display() }}</span></div>
-        </div>
-        {% endif %}
-        {% if row.sunday_headway_mins.is_some() %}
-        <div class="day-col">
-          <div class="day-col__hdr">Sunday</div>
-          <div class="spacing-stat-num spacing-{{ row.sunday_badge_variant() }}">{{ row.sunday_display() }}</div>
-          <div class="day-col__stat"><span class="day-col__lbl">Top 10%</span><span>{{ row.sunday_top_decile_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Max</span><span>{{ row.sunday_max_headway_display() }}</span></div>
-          <div class="day-col__stat"><span class="day-col__lbl">Span</span><span>{{ row.sunday_service_span_display() }}</span></div>
-        </div>
-        {% endif %}
+        {% endfor %}
       </div>
     </div>
-    {% endfor %}
-    {% endfor %}
-  </div>
+  </details>
+  {% endfor %}
   {% endif %}
 </div>

--- a/crates/worker/src/feed_ingestion/realtime.rs
+++ b/crates/worker/src/feed_ingestion/realtime.rs
@@ -266,12 +266,26 @@ mod tests {
     use mobilispect_core::db::test_utils;
     use mobilispect_core::ids::FeedId;
 
+    async fn create_stop_time_events_partition(pool: &sqlx::PgPool) {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS stop_time_events_test_part \
+             PARTITION OF stop_time_events \
+             FOR VALUES FROM ('2020-01-01') TO ('2030-01-01')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     #[tokio::test]
     async fn dwell_secs_computed_from_timestamps() {
         let test_db = test_utils::setup().await;
         let pool = &test_db.db.pool;
         let feed_id: i64 = 1;
         let observed_at = Utc::now();
+
+        // Create a partition covering the current date so inserts succeed.
+        create_stop_time_events_partition(pool).await;
         let arrival = chrono::DateTime::from_timestamp(1000, 0).unwrap();
         let departure = chrono::DateTime::from_timestamp(1045, 0).unwrap();
 
@@ -308,6 +322,9 @@ mod tests {
         let pool = &test_db.db.pool;
         let feed_id: i64 = 1;
         let observed_at = Utc::now();
+
+        // Create a partition covering the current date so inserts succeed.
+        create_stop_time_events_partition(pool).await;
         let departure = chrono::DateTime::from_timestamp(1045, 0).unwrap();
 
         sqlx::query!(

--- a/crates/worker/src/feed_ingestion/static_feed.rs
+++ b/crates/worker/src/feed_ingestion/static_feed.rs
@@ -320,10 +320,11 @@ async fn resolve_stops(
 ) -> Result<HashMap<String, StopId>> {
     let mut map: HashMap<String, StopId> = HashMap::new();
     let mut skipped = 0usize;
+    let resolved_stops = transitland.resolve_stops_for_feed(tl_feed_id).await?;
 
     for (gtfs_stop_id, stop) in &gtfs.stops {
-        match transitland.resolve_stop(gtfs_stop_id, tl_feed_id).await {
-            Ok(Some((stop_onestop_id, maybe_station_id))) => {
+        match resolved_stops.get(gtfs_stop_id).cloned() {
+            Some((stop_onestop_id, maybe_station_id)) => {
                 // Upsert parent station if present
                 if let Some(station_id) = &maybe_station_id {
                     let (lat, lon) = (stop.latitude.unwrap_or(0.0), stop.longitude.unwrap_or(0.0));
@@ -385,17 +386,10 @@ async fn resolve_stops(
 
                 map.insert(gtfs_stop_id.clone(), stop_onestop_id);
             }
-            Ok(None) => {
+            None => {
                 warn!(
                     "Transitland: no match for stop {} in feed {} — skipping",
                     gtfs_stop_id, tl_feed_id
-                );
-                skipped += 1;
-            }
-            Err(e) => {
-                warn!(
-                    "Transitland: error resolving stop {} in feed {}: {:#} — skipping",
-                    gtfs_stop_id, tl_feed_id, e
                 );
                 skipped += 1;
             }

--- a/crates/worker/src/maintenance/mod.rs
+++ b/crates/worker/src/maintenance/mod.rs
@@ -140,55 +140,133 @@ mod tests {
         }
     }
 
+    fn test_feed() -> mobilispect_core::config::FeedConfig {
+        mobilispect_core::config::FeedConfig {
+            id: 1,
+            name: "Test Feed".to_string(),
+            gtfs_static_url: "http://test".to_string(),
+            gtfs_rt_vehicle_positions_url: None,
+            gtfs_rt_trip_updates_url: None,
+            gtfs_api_key: None,
+            agency_utc_offset: "UTC".to_string(),
+            transitland_feed_id: None,
+        }
+    }
+
     /// Insert minimal static GTFS + one trip's stop time events for the given `observed_at` timestamp.
     async fn insert_speed_data(pool: &sqlx::PgPool, observed_at: &str) {
-        sqlx::query("INSERT INTO routes VALUES ('0', 'R1', '1', 'Route 1', 3)")
-            .execute(pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO trips VALUES ('0', 'T1', 'R1', 'WD', 0, 'Dest')")
-            .execute(pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S1', 'Stop 1', 45.50, -73.50)")
-            .execute(pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO stops VALUES ('0', 'S2', 'Stop 2', 45.51, -73.50)")
-            .execute(pool)
-            .await
-            .unwrap();
+        // Feed and agency must exist before routes/trips (FK constraints).
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S1', 1, '08:00:00', '08:00:00')",
+            "INSERT INTO feeds (id, gtfs_static_url) VALUES (1, 'http://test') ON CONFLICT DO NOTHING",
         )
         .execute(pool)
         .await
         .unwrap();
         sqlx::query(
-            "INSERT INTO scheduled_stops VALUES ('0', 'T1', 'S2', 2, '08:10:00', '08:10:00')",
+            "INSERT INTO agencies (onestop_id, name) VALUES ('A1', 'Test Agency') ON CONFLICT DO NOTHING",
         )
         .execute(pool)
         .await
         .unwrap();
-        // Two stop time events for the trip with distinct arrival_time_unix values.
-        let t1: i64 = 1_767_225_600;
-        let t2: i64 = t1 + 900;
+
+        // Canonical route (onestop_id-keyed, agency_id references agencies.onestop_id).
+        sqlx::query(
+            "INSERT INTO routes (onestop_id, agency_id, short_name, long_name, route_type)
+             VALUES ('R1', 'A1', '1', 'Route 1', 3) ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Mapping from GTFS route_id → onestop_id so compute_route_speed_daily can join.
+        sqlx::query(
+            "INSERT INTO feed_route_ids (feed_id, gtfs_route_id, onestop_id)
+             VALUES (1, 'R1', 'R1') ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Canonical stops.
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon)
+             VALUES ('S1', 'Stop 1', 45.50, -73.50) ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO stops (onestop_id, name, lat, lon)
+             VALUES ('S2', 'Stop 2', 45.51, -73.50) ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Route variant (route_id = GTFS route_id 'R1', direction_id 0, is_primary = true).
+        sqlx::query(
+            "INSERT INTO route_variants (feed_id, variant_id, route_id, direction_id, stop_count, trip_count, is_primary)
+             VALUES (1, 'VAR1', 'R1', 0, 2, 1, true) ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Trip belonging to the variant.
+        sqlx::query(
+            "INSERT INTO trips (feed_id, trip_id, variant_id, service_id)
+             VALUES (1, 'T1', 'VAR1', 'WD') ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Scheduled stops for the trip.
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (1, 'T1', 'S1', 1, '08:00:00', '08:00:00') ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO scheduled_stops (feed_id, trip_id, stop_id, stop_sequence, arrival_time, departure_time)
+             VALUES (1, 'T1', 'S2', 2, '08:10:00', '08:10:00') ON CONFLICT DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Partition for stop_time_events (partitioned table requires a matching partition).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS stop_time_events_maint_test_part \
+             PARTITION OF stop_time_events \
+             FOR VALUES FROM ('2020-01-01') TO ('2030-01-01')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        // Two stop time events with TIMESTAMPTZ arrival_time (15 min apart → ~1.235 m/s).
+        let t1 = chrono::DateTime::from_timestamp(1_767_225_600, 0).unwrap();
+        let t2 = chrono::DateTime::from_timestamp(1_767_225_600 + 900, 0).unwrap();
+        let observed: chrono::DateTime<chrono::Utc> = observed_at.parse().unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', $1, 'T1', 'S1', 1, $2)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (1, $1, 'T1', 'S1', 1, $2)",
         )
-        .bind(observed_at)
+        .bind(observed)
         .bind(t1)
         .execute(pool)
         .await
         .unwrap();
         sqlx::query(
             "INSERT INTO stop_time_events
-             (agency_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time_unix)
-             VALUES ('0', $1, 'T1', 'S2', 2, $2)",
+             (feed_id, observed_at, trip_id, stop_id, stop_sequence, arrival_time)
+             VALUES (1, $1, 'T1', 'S2', 2, $2)",
         )
-        .bind(observed_at)
+        .bind(observed)
         .bind(t2)
         .execute(pool)
         .await
@@ -211,18 +289,18 @@ mod tests {
         let observed_at = format!("{}T12:00:00Z", yesterday);
         insert_speed_data(&td.db.pool, &observed_at).await;
 
-        backfill_daily_metrics(&td.db, &test_config(), &[], 1).await;
+        backfill_daily_metrics(&td.db, &test_config(), &[test_feed()], 1).await;
 
         let (count,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM route_speed_daily WHERE route_id = 'R1' AND service_date = $1",
+            "SELECT COUNT(*) FROM route_daily_stats WHERE route_id = 'R1' AND service_date = $1",
         )
-        .bind(yesterday.to_string())
+        .bind(yesterday)
         .fetch_one(&td.db.pool)
         .await
         .unwrap();
         assert!(
             count > 0,
-            "backfill must populate route_speed_daily for yesterday"
+            "backfill must populate route_daily_stats for yesterday"
         );
     }
 
@@ -239,19 +317,35 @@ mod tests {
         let handle = tokio::spawn(async move {
             retention_loop(&db_clone, &config).await;
         });
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let (count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM route_daily_stats WHERE route_id = 'R1' AND service_date = $1",
+            )
+            .bind(yesterday)
+            .fetch_one(&td.db.pool)
+            .await
+            .unwrap();
+            if count > 0 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
         handle.abort();
 
-        let (count,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM route_speed_daily WHERE route_id = 'R1' AND service_date = $1",
+        let (final_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM route_daily_stats WHERE route_id = 'R1' AND service_date = $1",
         )
-        .bind(yesterday.to_string())
+        .bind(yesterday)
         .fetch_one(&td.db.pool)
         .await
         .unwrap();
         assert!(
-            count > 0,
-            "retention_loop must compute route_speed_daily for yesterday on first tick"
+            final_count > 0,
+            "retention_loop must compute route_daily_stats for yesterday on first tick"
         );
     }
 }

--- a/docs/superpowers/plans/2026-06-06-transitland-bulk-stop-resolution.md
+++ b/docs/superpowers/plans/2026-06-06-transitland-bulk-stop-resolution.md
@@ -1,0 +1,143 @@
+# Transitland Bulk Stop Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-stop Transitland requests during static ingestion with paginated feed-wide stop resolution.
+
+**Architecture:** `TransitlandClient` fetches all stops for a feed by following Transitland pagination cursors and returns a map keyed by GTFS stop ID. The worker resolves its parsed GTFS stops from that map while preserving existing database writes and warnings.
+
+**Tech Stack:** Rust 2024, Tokio, reqwest, serde, wiremock, cargo test
+
+---
+
+### Task 1: Add Paginated Feed Stop Resolution
+
+**Files:**
+- Modify: `crates/core/src/transitland/mod.rs`
+- Test: `crates/core/src/transitland/mod.rs`
+
+- [ ] **Step 1: Write a failing single-page mapping test**
+
+Add a wiremock test that returns two stop records from `/stops.json`, including their
+`stop_id`, `onestop_id`, and an optional `parent`. Call `resolve_stops_for_feed` and assert
+that both GTFS IDs map to the expected canonical IDs.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-core resolve_stops_for_feed_returns_map
+```
+
+Expected: compilation fails because `resolve_stops_for_feed` does not exist.
+
+- [ ] **Step 3: Implement the minimal single-page method**
+
+Add `stop_id` and pagination metadata to the private serde models. Implement
+`resolve_stops_for_feed` with `feed_onestop_id` and `limit=1000`, converting returned
+records into a `HashMap<String, (StopId, Option<StationId>)>`.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-core resolve_stops_for_feed_returns_map
+```
+
+Expected: one test passes.
+
+- [ ] **Step 5: Write a failing pagination test**
+
+Configure page one to return `meta.after = 42` and page two to require `after=42`.
+Assert records from both pages are returned and each mock is called once.
+
+- [ ] **Step 6: Run the pagination test and verify it fails**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-core resolve_stops_for_feed_follows_pagination
+```
+
+Expected: failure because the client only requests the first page.
+
+- [ ] **Step 7: Implement cursor pagination**
+
+Loop requests while `meta.after` is present. Add the opaque cursor as an `after` query
+parameter on subsequent requests and merge each page into the result map.
+
+- [ ] **Step 8: Run Transitland client tests**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-core transitland::tests
+```
+
+Expected: all Transitland tests pass.
+
+### Task 2: Use Bulk Resolution During Static Ingestion
+
+**Files:**
+- Modify: `crates/worker/src/feed_ingestion/static_feed.rs`
+
+- [ ] **Step 1: Replace per-stop calls with one feed-wide request**
+
+At the start of `resolve_stops`, call:
+
+```rust
+let resolved = transitland.resolve_stops_for_feed(tl_feed_id).await?;
+```
+
+Inside the GTFS stop loop, replace the async `resolve_stop` match with a lookup in
+`resolved`. Preserve the existing upsert behavior and missing-match warning.
+
+- [ ] **Step 2: Run worker feed ingestion tests**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-worker feed_ingestion
+```
+
+Expected: all feed ingestion tests pass.
+
+### Task 3: Verify the Workspace
+
+**Files:**
+- Verify: `crates/core/src/transitland/mod.rs`
+- Verify: `crates/worker/src/feed_ingestion/static_feed.rs`
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fm
+```
+
+Expected: formatting succeeds.
+
+- [ ] **Step 2: Run focused package tests**
+
+Run:
+
+```bash
+dotenvx run -- cargo test -p mobilispect-core transitland::tests
+dotenvx run -- cargo test -p mobilispect-worker feed_ingestion
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+dotenvx run -- cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: no warnings or errors.
+

--- a/docs/superpowers/specs/2026-06-06-transitland-bulk-stop-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-06-transitland-bulk-stop-resolution-design.md
@@ -1,0 +1,77 @@
+# Transitland Bulk Stop Resolution
+
+**Date:** 2026-06-06
+**Status:** Approved
+
+## Problem
+
+Static feed ingestion currently calls Transitland once for every GTFS stop. Large feeds
+therefore make hundreds or thousands of REST requests and exceed Transitland's Free Tier
+rate limit. Each `429 Too Many Requests` response causes the current stop to be skipped,
+leaving incomplete canonical stop and route-variant data.
+
+## Design
+
+Add a feed-wide stop lookup to `TransitlandClient`:
+
+```rust
+pub async fn resolve_stops_for_feed(
+    &self,
+    feed_onestop_id: &str,
+) -> anyhow::Result<HashMap<String, (StopId, Option<StationId>)>>
+```
+
+The method requests `/stops.json` with `feed_onestop_id` and a page limit. It follows the
+opaque `meta.after` cursor until no next cursor remains. Each response record supplies the
+GTFS `stop_id`, canonical stop `onestop_id`, and optional parent station `onestop_id`.
+
+Static ingestion calls this method once before iterating its GTFS stops. The existing loop
+then performs local lookups by GTFS stop ID and retains its current database writes and
+missing-match warnings.
+
+The existing single-stop `resolve_stop` method remains unchanged for compatibility.
+
+## Response Model
+
+The private stop response model gains:
+
+```rust
+struct StopsResponse {
+    stops: Vec<StopRecord>,
+    meta: Option<PaginationMeta>,
+}
+
+struct StopRecord {
+    stop_id: String,
+    onestop_id: String,
+    parent: Option<StationRecord>,
+}
+
+struct PaginationMeta {
+    after: Option<i64>,
+}
+```
+
+Transitland's current v2 response names the parent relationship `parent`. Deserialization
+accepts the legacy `parent_station` name as an alias so existing fixtures and compatible
+responses continue to work.
+
+## Error Handling
+
+- Any network or non-success HTTP response aborts feed-wide stop resolution.
+- Static ingestion propagates that error instead of treating every remaining stop as an
+  independent miss.
+- Empty pages and missing `meta.after` values terminate pagination.
+- Duplicate GTFS stop IDs use the last record returned by Transitland.
+
+## Testing
+
+Wiremock tests cover:
+
+1. A single-page feed response mapped by GTFS stop ID.
+2. Multiple pages linked by `meta.after`.
+3. Parent station mapping.
+4. HTTP errors propagated from any page.
+
+Existing Transitland and worker tests continue to pass.
+


### PR DESCRIPTION
## Summary

- Fixes test fixtures for schema migrations 011–015 and enables Transitland API key config
- Resolves Transitland bulk feed stop lookups and parent stop resolution by GTFS ID
- Populates agency filter on speed and schedule pages
- Replaces the flat schedule card grid with collapsible accordion groups, each sorted by frequency:
  - **Every Day** — weekday + weekend service (or weekend-only)
  - **Weekday — All Day** — weekday-only, continuous service ≥ 8 h with no gap > 3 h
  - **Weekday — Rush Hours** — weekday-only, short span or large midday gap
  - **Night** — any route whose primary service starts at or after midnight (GTFS past-midnight encoding ≥ 24:00:00)
- Route schedule sort order updated: span DESC as primary key, headway ASC as secondary

## Test plan

- [ ] `cargo nextest run` — all 302 tests pass
- [ ] `/frequency` page renders accordion groups with correct titles and route counts
- [ ] Accordions collapse and expand; chevron animates
- [ ] Night routes (start ≥ 24:00 GTFS) appear in the Night group
- [ ] Agency filter still works on schedule and speed pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)